### PR TITLE
bugfix: remove unnecessary annotation

### DIFF
--- a/triggers/triggers.go
+++ b/triggers/triggers.go
@@ -23,8 +23,8 @@ type NotificationTrigger struct {
 }
 
 type NotificationTemplate struct {
-	notifiers.Notification `json:"-"`
-	Name                   string `json:"name,omitempty"`
+	notifiers.Notification
+	Name string `json:"name,omitempty"`
 }
 
 type Trigger interface {


### PR DESCRIPTION
# remove unnecessary annotation

For Marshal/Unmarshal an embedded struct, this annotation should be removed.
Because of this annotation, custom templates cannot be registered.

## TODO

- make `parseConfig` more testable.

I was trying to write a test code. but, current implementation of `parseConfig` is not testable against `config.yaml` input.
