### PR TITLE
Add testcase to parse notifier.yaml

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,6 +127,13 @@ func parseConfigMapYaml(configData map[string]string) (cfg *config, err error) {
 	}
 	return cfg, nil
 }
+func parseSecretYaml(notifiersData []byte) (notifiersConfig notifiers.Config, err error) {
+	err = yaml.Unmarshal(notifiersData, &notifiersConfig)
+	if err != nil {
+		return notifiers.Config{}, err
+	}
+	return notifiersConfig, nil
+}
 func parseConfig(configData map[string]string, notifiersData []byte) (map[string]triggers.Trigger, map[string]notifiers.Notifier, map[string]string, error) {
 	cfg, err := parseConfigMapYaml(configData)
 	if err != nil {
@@ -137,9 +144,7 @@ func parseConfig(configData map[string]string, notifiersData []byte) (map[string
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	notifiersConfig := notifiers.Config{}
-	err = yaml.Unmarshal(notifiersData, &notifiersConfig)
+	notifiersConfig, err := parseSecretYaml(notifiersData)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -48,7 +48,6 @@ templates:
 context:
     argocdUrl: testUrl`}
 
-	chk := true
 	expectCfg := &config{
 		Triggers: []triggers.NotificationTrigger{
 			{
@@ -56,7 +55,7 @@ context:
 				Condition:   "app.status.operationState.phase in ['Custom']",
 				Description: "Application custom trigger",
 				Template:    "app-sync-status",
-				Enabled:     &chk,
+				Enabled:     pointer.BoolPtr(true),
 			},
 		},
 		Templates: []triggers.NotificationTemplate{{

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -88,9 +88,46 @@ Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
 	}
 	actualCfg, err := parseConfigMapYaml(configData)
 	assert.NoError(t, err)
-	assert.Equal(t, expectCfg.Templates, actualCfg.Templates)
-	assert.Equal(t, expectCfg.Triggers, actualCfg.Triggers)
-	assert.Equal(t, expectCfg.Context, actualCfg.Context)
+	assert.Equal(t, expectCfg, actualCfg)
+}
+
+func TestParseSecretYaml(t *testing.T) {
+	notifiersData := []byte(`
+email:
+  host: smtp.gmail.com
+  port: 587
+  from: <myemail>@gmail.com
+  username: <myemail>@gmail.com
+  password: <mypassword>
+slack:
+  token: <my-token>
+opsgenie:
+  apiUrl: api.opsgenie.com
+  apiKeys:
+    <team-id>: <my-api-key>`)
+
+	expectNotifiersCfg := notifiers.Config{
+		Email: &notifiers.EmailOptions{
+			Host:               "smtp.gmail.com",
+			Port:               587,
+			From:               "<myemail>@gmail.com",
+			InsecureSkipVerify: false,
+			Username:           "<myemail>@gmail.com",
+			Password:           "<mypassword>",
+		},
+		Slack: &notifiers.SlackOptions{
+			Token:              "<my-token>",
+			Channels:           nil,
+			InsecureSkipVerify: false,
+		},
+		Opsgenie: &notifiers.OpsgenieOptions{
+			ApiUrl:  "api.opsgenie.com",
+			ApiKeys: map[string]string{"<team-id>": "<my-api-key>"},
+		},
+	}
+	actualNotifiersCfg, err := parseSecretYaml(notifiersData)
+	assert.NoError(t, err)
+	assert.Equal(t, expectNotifiersCfg, actualNotifiersCfg)
 }
 
 func TestMergeConfigTemplate(t *testing.T) {

--- a/docs/argocd-notifications-secret.yaml
+++ b/docs/argocd-notifications-secret.yaml
@@ -15,6 +15,6 @@ stringData:
     opsgenie:
       apiUrl: api.opsgenie.com
       apiKeys:
-        <team-id>:<my-api-key>
+        <team-id>: <my-api-key>
         ...
 type: Opaque


### PR DESCRIPTION
# Description
- Divide the parse part of notifier.yaml into functions
- Add testcase to parse notifier.yaml
- Fixed indent of sample docs/argocd-notifications-secret.yaml 

# Comment
- In the future, I think that it is better to parse the yaml into another module, but I think it is not at that time yet, so I added only the test.