### PR TITLE
Provide expr.Env while evaluating trigger condition

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -30,6 +32,13 @@ func WithSyncStatus(status string) func(app *unstructured.Unstructured) {
 func WithSyncOperationPhase(phase string) func(app *unstructured.Unstructured) {
 	return func(app *unstructured.Unstructured) {
 		_ = unstructured.SetNestedField(app.Object, phase, "status", "operationState", "phase")
+	}
+}
+
+func WithSyncOperationStartAt(t time.Time) func(app *unstructured.Unstructured) {
+	return func(app *unstructured.Unstructured) {
+		ts := t.Format(time.RFC3339)
+		_ = unstructured.SetNestedField(app.Object, ts, "status", "operationState", "startedAt")
 	}
 }
 

--- a/triggers/expr/expr.go
+++ b/triggers/expr/expr.go
@@ -1,0 +1,20 @@
+package expr
+
+var helpers map[string]interface{}
+
+func init() {
+	helpers = make(map[string]interface{})
+}
+
+func register(namespace string, entry map[string]interface{}) {
+	helpers[namespace] = entry
+}
+
+func Spawn() map[string]interface{} {
+	clone := make(map[string]interface{})
+	for namespace, helper := range helpers {
+		clone[namespace] = helper
+	}
+
+	return clone
+}

--- a/triggers/expr/expr_test.go
+++ b/triggers/expr/expr_test.go
@@ -1,0 +1,19 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpr(t *testing.T) {
+	namespaces := []string{
+		"time",
+	}
+
+	for _, ns := range namespaces {
+		helpers := Spawn()
+		_, hasNamespace := helpers[ns]
+		assert.True(t, hasNamespace)
+	}
+}

--- a/triggers/expr/time.go
+++ b/triggers/expr/time.go
@@ -5,11 +5,14 @@ import (
 )
 
 func init() {
-	helpers := map[string]interface{}{
+	register("time", newTimeExprs())
+}
+
+func newTimeExprs() map[string]interface{} {
+	return map[string]interface{}{
 		"Parse": parse,
 		"Now":   now,
 	}
-	register("time", helpers)
 }
 
 func parse(timestamp string) time.Time {

--- a/triggers/expr/time.go
+++ b/triggers/expr/time.go
@@ -1,0 +1,25 @@
+package expr
+
+import (
+	"time"
+)
+
+func init() {
+	helpers := map[string]interface{}{
+		"parse": toTime,
+		"now":   now,
+	}
+	register("time", helpers)
+}
+
+func toTime(timestamp string) time.Time {
+	res, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+func now() time.Time {
+	return time.Now()
+}

--- a/triggers/expr/time.go
+++ b/triggers/expr/time.go
@@ -6,13 +6,13 @@ import (
 
 func init() {
 	helpers := map[string]interface{}{
-		"parse": toTime,
-		"now":   now,
+		"Parse": parse,
+		"Now":   now,
 	}
 	register("time", helpers)
 }
 
-func toTime(timestamp string) time.Time {
+func parse(timestamp string) time.Time {
 	res, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
 		panic(err)

--- a/triggers/expr/time_test.go
+++ b/triggers/expr/time_test.go
@@ -1,0 +1,20 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTimeExprs(t *testing.T) {
+	funcs := []string{
+		"Parse",
+		"Now",
+	}
+
+	for _, fn := range funcs {
+		timeExprs := newTimeExprs()
+		_, hasFunc := timeExprs[fn]
+		assert.True(t, hasFunc)
+	}
+}

--- a/triggers/triggers.go
+++ b/triggers/triggers.go
@@ -6,13 +6,13 @@ import (
 	"bytes"
 	"fmt"
 	htmptemplate "html/template"
-	"time"
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/argoproj-labs/argocd-notifications/notifiers"
+	exprHelpers "github.com/argoproj-labs/argocd-notifications/triggers/expr"
 )
 
 type NotificationTrigger struct {
@@ -54,16 +54,7 @@ func GetTriggers(templatesCfg []NotificationTemplate, triggersCfg []Notification
 }
 
 func spawnExprEnvs(opts map[string]interface{}) interface{} {
-	envs := map[string]interface{}{
-		"toTime": func(timestamp string) time.Time {
-			res, err := time.Parse(time.RFC3339, timestamp)
-			if err != nil {
-				panic(err)
-			}
-			return res
-		},
-		"now": func() time.Time { return time.Now() },
-	}
+	envs := exprHelpers.Spawn()
 	for name, env := range opts {
 		envs[name] = env
 	}

--- a/triggers/triggers_test.go
+++ b/triggers/triggers_test.go
@@ -142,7 +142,7 @@ func TestGetTriggers_UsingExprVm(t *testing.T) {
 	}}, []NotificationTrigger{{
 		Name:      "trigger",
 		Template:  "template",
-		Condition: "app.metadata.name == 'foo' && app.status.operationState.phase in ['Running'] && time.now().Sub(time.parse(app.status.operationState.startedAt)).Minutes() >= 5",
+		Condition: "app.metadata.name == 'foo' && app.status.operationState.phase in ['Running'] && time.Now().Sub(time.Parse(app.status.operationState.startedAt)).Minutes() >= 5",
 	}})
 	assert.NoError(t, err)
 

--- a/triggers/triggers_test.go
+++ b/triggers/triggers_test.go
@@ -126,10 +126,6 @@ func TestSpawnExprEnvs(t *testing.T) {
 
 	_, hasApp := envs["app"]
 	assert.True(t, hasApp)
-
-	_, hasTimeNamespace := envs["time"]
-	assert.True(t, hasTimeNamespace)
-
 }
 
 func TestGetTriggers_UsingExprVm(t *testing.T) {

--- a/triggers/triggers_test.go
+++ b/triggers/triggers_test.go
@@ -124,14 +124,11 @@ func TestSpawnExprEnvs(t *testing.T) {
 	envs, ok := spawnExprEnvs(opts).(map[string]interface{})
 	assert.True(t, ok)
 
-	_, hasToTime := envs["toTime"]
-	assert.True(t, hasToTime)
-
-	_, hasNow := envs["now"]
-	assert.True(t, hasNow)
-
 	_, hasApp := envs["app"]
 	assert.True(t, hasApp)
+
+	_, hasTimeNamespace := envs["time"]
+	assert.True(t, hasTimeNamespace)
 
 }
 
@@ -145,7 +142,7 @@ func TestGetTriggers_UsingExprVm(t *testing.T) {
 	}}, []NotificationTrigger{{
 		Name:      "trigger",
 		Template:  "template",
-		Condition: "app.metadata.name == 'foo' && app.status.operationState.phase in ['Running'] && now().Sub(toTime(app.status.operationState.startedAt)).Minutes() >= 5",
+		Condition: "app.metadata.name == 'foo' && app.status.operationState.phase in ['Running'] && time.now().Sub(time.parse(app.status.operationState.startedAt)).Minutes() >= 5",
 	}})
 	assert.NoError(t, err)
 

--- a/triggers/triggers_test.go
+++ b/triggers/triggers_test.go
@@ -2,6 +2,7 @@ package triggers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/argoproj-labs/argocd-notifications/notifiers"
 
@@ -116,4 +117,52 @@ func TestGetTriggers_UsingSlack(t *testing.T) {
 	assert.Equal(t, "the body: test", notification.Body)
 	assert.Equal(t, "Application test Application details: testUrl/applications/test.", notification.Slack.Attachments)
 	assert.Equal(t, "Application test Application details: testUrl/applications/test.", notification.Slack.Blocks)
+}
+
+func TestSpawnExprEnvs(t *testing.T) {
+	opts := map[string]interface{}{"app": "dummy"}
+	envs, ok := spawnExprEnvs(opts).(map[string]interface{})
+	assert.True(t, ok)
+
+	_, hasToTime := envs["toTime"]
+	assert.True(t, hasToTime)
+
+	_, hasNow := envs["now"]
+	assert.True(t, hasNow)
+
+	_, hasApp := envs["app"]
+	assert.True(t, hasApp)
+
+}
+
+func TestGetTriggers_UsingExprVm(t *testing.T) {
+	triggers, err := GetTriggers([]NotificationTemplate{{
+		Name: "template",
+		Notification: notifiers.Notification{
+			Title: "the title: {{.app.metadata.name}}",
+			Body:  "the body: {{.app.metadata.name}}",
+		},
+	}}, []NotificationTrigger{{
+		Name:      "trigger",
+		Template:  "template",
+		Condition: "app.metadata.name == 'foo' && app.status.operationState.phase in ['Running'] && now().Sub(toTime(app.status.operationState.startedAt)).Minutes() >= 5",
+	}})
+	assert.NoError(t, err)
+
+	trigger, ok := triggers["trigger"]
+	assert.True(t, ok)
+
+	before2Minute := time.Now().Add(-2 * time.Minute)
+	ok, err = trigger.Triggered(testingutil.NewApp("bar",
+		testingutil.WithSyncOperationPhase("Running"),
+		testingutil.WithSyncOperationStartAt(before2Minute)))
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	before5Minute := time.Now().Add(-5 * time.Minute)
+	ok, err = trigger.Triggered(testingutil.NewApp("foo",
+		testingutil.WithSyncOperationPhase("Running"),
+		testingutil.WithSyncOperationStartAt(before5Minute)))
+	assert.NoError(t, err)
+	assert.True(t, ok)
 }


### PR DESCRIPTION
# Description

Provide `expr.Env` while evaluating trigger condition. At this time, only 2 functions are provided.

- `toTime(t string)` : parse t as RFC3339, return `time.Time`
- `now()` : return current time as `time.Time`

with this feature, we can notify long-running operations.
close #17 