### PR TITLE
feat: override notification slack username

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -101,6 +101,7 @@ email:
   password: <mypassword>
 slack:
   token: <my-token>
+  username: <override-username>
 opsgenie:
   apiUrl: api.opsgenie.com
   apiKeys:
@@ -116,6 +117,7 @@ opsgenie:
 			Password:           "<mypassword>",
 		},
 		Slack: &notifiers.SlackOptions{
+			Username:           "<override-username>",
 			Token:              "<my-token>",
 			Channels:           nil,
 			InsecureSkipVerify: false,

--- a/docs/argocd-notifications-secret.yaml
+++ b/docs/argocd-notifications-secret.yaml
@@ -11,6 +11,7 @@ stringData:
       username: <myemail>@gmail.com
       password: <mypassword>
     slack:
+      username: <override-username>
       token: <my-token>
     opsgenie:
       apiUrl: api.opsgenie.com

--- a/notifiers/slack.go
+++ b/notifiers/slack.go
@@ -33,7 +33,10 @@ func (n *slackNotifier) Send(notification Notification, recipient string) error 
 		},
 	}
 	s := slack.New(n.opts.Token, slack.OptionHTTPClient(client))
-	msgOptions := []slack.MsgOption{slack.MsgOptionText(notification.Body, false), slack.MsgOptionUsername(n.opts.Username)}
+	msgOptions := []slack.MsgOption{slack.MsgOptionText(notification.Body, false)}
+	if n.opts.Username != "" {
+		msgOptions = append(msgOptions, slack.MsgOptionUsername(n.opts.Username))
+	}
 
 	if notification.Slack != nil {
 		attachments := make([]slack.Attachment, 0)

--- a/notifiers/slack.go
+++ b/notifiers/slack.go
@@ -10,6 +10,7 @@ import (
 )
 
 type SlackOptions struct {
+	Username           string   `json:"username"`
 	Token              string   `json:"token"`
 	Channels           []string `json:"channels"`
 	InsecureSkipVerify bool     `json:"insecureSkipVerify"`
@@ -32,7 +33,7 @@ func (n *slackNotifier) Send(notification Notification, recipient string) error 
 		},
 	}
 	s := slack.New(n.opts.Token, slack.OptionHTTPClient(client))
-	msgOptions := []slack.MsgOption{slack.MsgOptionText(notification.Body, false)}
+	msgOptions := []slack.MsgOption{slack.MsgOptionText(notification.Body, false), slack.MsgOptionUsername(n.opts.Username)}
 
 	if notification.Slack != nil {
 		attachments := make([]slack.Attachment, 0)


### PR DESCRIPTION
# Description
- If slack username is specified in notifer.yaml, the username set in token is overwritten with the specified username