### PR TITLE
feat: Add icon emoij and icon url support for Slack messages (fixes #47)

### DIFF
--- a/docs/argocd-notifications-secret.yaml
+++ b/docs/argocd-notifications-secret.yaml
@@ -13,6 +13,7 @@ stringData:
     slack:
       token: <my-token>
       username: <override-username> # optional username
+      icon: <override-icon> # optional icon for the message (supports both emoij and url notation)
     opsgenie:
       apiUrl: api.opsgenie.com
       apiKeys:

--- a/notifiers/slack_test.go
+++ b/notifiers/slack_test.go
@@ -1,0 +1,21 @@
+package notifiers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidIconEmoij(t *testing.T) {
+	assert.Equal(t, true, validIconEmoij.MatchString(":slack:"))
+	assert.Equal(t, true, validIconEmoij.MatchString(":chart_with_upwards_trend:"))
+	assert.Equal(t, false, validIconEmoij.MatchString("http://lorempixel.com/48/48"))
+}
+
+func TestValidIconURL(t *testing.T) {
+	assert.Equal(t, true, isValidIconURL("http://lorempixel.com/48/48"))
+	assert.Equal(t, true, isValidIconURL("https://lorempixel.com/48/48"))
+	assert.Equal(t, false, isValidIconURL("favicon.ico"))
+	assert.Equal(t, false, isValidIconURL("ftp://favicon.ico"))
+	assert.Equal(t, false, isValidIconURL("ftp://lorempixel.com/favicon.ico"))
+}


### PR DESCRIPTION
Allows to define an 'icon' field in Slack notifier options. It has very simple validation to check if it is emoij notation or url notation and sets the Slack msg options accordingly.

fixes #47 