### PR TITLE
Grafana annotation notifier

### DIFF
--- a/docs/recipients/overview.md
+++ b/docs/recipients/overview.md
@@ -22,6 +22,16 @@ metadata:
     recipients.argocd-notifications.argoproj.io: slack:<sample-channel-name>
 ```
 
+The example below demonstrates how to create a Grafana annotation for a specific application:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    recipients.argocd-notifications.argoproj.io: grafana:tag1|tag2
+```
+
 Each recipient is prefixed with the [notification service type](../services/overview.md) such as `slack` or `email`.
 
 ## Trigger Specific Subscription (v0.3)

--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -1,0 +1,22 @@
+# Grafana
+
+To be able to create Grafana annotation with argocd-notifications you have to create an [API Key](https://grafana.com/docs/grafana/latest/http_api/auth/#create-api-key) inside your [Grafana](https://grafana.com).
+
+1. Login to your Grafana instance as `admin`
+2. On the left menu, go to Configuration / API Keys
+3. Click "Add API Key" 
+4. Fill the Key with name `ArgoCD Notification`, role `Editor` and Time to Live `10y` (for example)
+5. Click on Add button
+6. Copy your API Key and define it in `notifiers.yaml`
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+stringData:
+  notifiers.yaml: |
+    grafana:
+      apiUrl: https://grafana.example.com/api
+      apiKey: <grafana-api-key> 
+```

--- a/notifiers/grafana.go
+++ b/notifiers/grafana.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type GrafanaOptions struct {

--- a/notifiers/grafana.go
+++ b/notifiers/grafana.go
@@ -1,0 +1,72 @@
+package notifiers
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+type GrafanaOptions struct {
+	ApiUrl             string `json:"apiUrl"`
+	ApiKey             string `json:"apiKey"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+}
+
+type grafanaNotifier struct {
+	opts GrafanaOptions
+}
+
+func NewGrafanaNotifier(opts GrafanaOptions) Notifier {
+	return &grafanaNotifier{opts: opts}
+}
+
+type GrafanaAnnotation struct {
+	Time     int64    `json:"time"` // unix ts in ms
+	IsRegion bool     `json:"isRegion"`
+	Tags     []string `json:"tags"`
+	Text     string   `json:"text"`
+}
+
+func (n *grafanaNotifier) Send(notification Notification, tags string) error {
+	ga := GrafanaAnnotation{
+		Time:     time.Now().Unix() * 1000, // unix ts in ms
+		IsRegion: false,
+		Tags:     strings.Split(tags, "|"),
+		Text:     notification.Title,
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: n.opts.InsecureSkipVerify,
+			},
+		},
+	}
+
+	jsonValue, _ := json.Marshal(ga)
+	apiUrl, err := url.Parse(n.opts.ApiUrl)
+
+	if err != nil {
+		return err
+	}
+	annotationApi := *apiUrl
+	annotationApi.Path = path.Join(apiUrl.Path, "annotations")
+	req, err := http.NewRequest("POST", annotationApi.String(), bytes.NewBuffer(jsonValue))
+	if err != nil {
+		log.Errorf("Failed to create grafana annotation request: %s", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", n.opts.ApiKey))
+
+	_, err = client.Do(req)
+	return err
+}

--- a/notifiers/grafana.go
+++ b/notifiers/grafana.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"path"

--- a/notifiers/notifiers.go
+++ b/notifiers/notifiers.go
@@ -4,6 +4,7 @@ type Config struct {
 	Email    *EmailOptions    `json:"email"`
 	Slack    *SlackOptions    `json:"slack"`
 	Opsgenie *OpsgenieOptions `json:"opsgenie"`
+	Grafana  *GrafanaOptions  `json:"grafana"`
 }
 
 type SlackSpecific struct {
@@ -33,6 +34,9 @@ func GetAll(config Config) map[string]Notifier {
 	}
 	if config.Opsgenie != nil {
 		res["opsgenie"] = NewOpsgenieNotifier(*config.Opsgenie)
+	}
+	if config.Grafana != nil {
+		res["grafana"] = NewGrafanaNotifier(*config.Grafana)
 	}
 	return res
 }

--- a/shared/settings/settings_test.go
+++ b/shared/settings/settings_test.go
@@ -25,7 +25,10 @@ slack:
 opsgenie:
   apiUrl: api.opsgenie.com
   apiKeys:
-    <team-id>: <my-api-key>`)
+    <team-id>: <my-api-key>
+grafana:
+  apiUrl: grafana.com/api
+  apiKey: <my-api-key>`)
 
 	expectNotifiersCfg := notifiers.Config{
 		Email: &notifiers.EmailOptions{
@@ -45,6 +48,10 @@ opsgenie:
 		Opsgenie: &notifiers.OpsgenieOptions{
 			ApiUrl:  "api.opsgenie.com",
 			ApiKeys: map[string]string{"<team-id>": "<my-api-key>"},
+		},
+		Grafana: &notifiers.GrafanaOptions{
+			ApiUrl: "grafana.com/api",
+			ApiKey: "<my-api-key>",
 		},
 	}
 	actualNotifiersCfg, err := ParseSecret(&v1.Secret{Data: map[string][]byte{"notifiers.yaml": notifiersData}})


### PR DESCRIPTION
Hi all,

Here is a PR to create a notifier for Grafana in order to create an annotation with specific tags.

In order to configure this notifier we have to configure the `notifiers.yaml` like that:

```
apiVersion: v1
kind: Secret
metadata:
  name: argocd-notifications-secret
stringData:
  notifiers.yaml: |
    grafana:
      apiUrl: https://grafana.example.com/api
      apiKey: <grafana-api-key> 
```

And the recipient has to be configured like that:

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
    recipients.argocd-notifications.argoproj.io: grafana:tag1|tag2
```
I chose `|` as separator for the tags cause `,` is already used for the notifiers.

Nicolas

