### PR TITLE
fix(doc): recipients are []string

### DIFF
--- a/docs/argocd-notifications-cm.yaml
+++ b/docs/argocd-notifications-cm.yaml
@@ -6,12 +6,17 @@ data:
   config.yaml: |
     subscriptions:
     # global subscription for all type of notifications
-    - recipients: slack:test1, webhook:github
+    - recipients:
+      - slack:test1
+      - webhook:github
     # subscription for on-sync-status-unknown trigger notifications
-    - recipients: slack:test2, email:test@gmail.com
+    - recipients:
+      - slack:test2
+      - email:test@gmail.com
       trigger: on-sync-status-unknown
     # global subscription restricted to applications with matching labels only
-    - recipients: slack:test3
+    - recipients:
+      - slack:test3
       selector: test=true
     triggers:
       # Enable existing built-in trigger


### PR DESCRIPTION
If you use the doc as-is you get:

```console
level=fatal msg="Failed to parse new settings: error unmarshaling JSON: json: cannot unmarshal string into Go struct field Config.subscriptions of type []string"
```