### PR TITLE
fix: ensure slack attachment properly formatted json object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## v0.7.0 (Unreleased)
 
+### Features
+
 * feat: support default subscriptions
+
+###  Bug Fixes
+
+
+## v0.6.1 (2020-03-20)
+
+### Features
+
+* feat: support default subscriptions
+* fix: ensure slack attachment properly formatted json object
 
 ## v0.6.0 (2020-03-13)
 

--- a/builtin/templates.go
+++ b/builtin/templates.go
@@ -9,25 +9,25 @@ import (
 
 const (
 	slackAttachmentTemplate = `[{
-	"title": "{{.app.metadata.name}}",
-	"title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+	"title": {{toJson .app.metadata.name}},
+	"title_link": {{toJson ( printf "%%s/applications/%%s" .context.argocdUrl .app.metadata.name )}},
 	"color": "%s",
 	"fields": [
 	{
 		"title": "Sync Status",
-		"value": "{{.app.status.sync.status}}",
+		"value": {{toJson .app.status.sync.status}},
 		"short": true
 	},
 	{
 		"title": "Repository",
-		"value": "{{.app.spec.source.repoURL}}",
+		"value": {{toJson .app.spec.source.repoURL}},
 		"short": true
 	}
 	{{range $index, $c := .app.status.conditions}}
 	{{if not $index}},{{end}}
 	{
-		"title": "{{$c.type}}",
-		"value": "{{$c.message}}",
+		"title": {{toJson $c.type}},
+		"value": {{toJson $c.message}},
 		"short": true
 	}
 	{{end}}

--- a/builtin/templates_test.go
+++ b/builtin/templates_test.go
@@ -1,0 +1,47 @@
+package builtin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/argoproj-labs/argocd-notifications/testing"
+	"github.com/argoproj-labs/argocd-notifications/triggers"
+)
+
+func triggerWithTemplate(name string) (triggers.Trigger, error) {
+	triggersByName, err := triggers.GetTriggers(Templates, []triggers.NotificationTrigger{{
+		Name:      "test",
+		Template:  name,
+		Condition: "true",
+	}})
+	if err != nil {
+		return nil, err
+	}
+	return triggersByName["test"], nil
+}
+
+func TestFormatNotification_SlackAttachment(t *testing.T) {
+	for i := range Templates {
+		trigger, err := triggerWithTemplate(Templates[i].Name)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		quotedString := `"wrong"`
+		n, err := trigger.FormatNotification(
+			NewApp(quotedString, WithConditions(quotedString, quotedString)), map[string]string{
+				"argocdUrl":        quotedString,
+				"notificationType": "slack",
+			})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		var attachments []map[string]interface{}
+		err = json.Unmarshal([]byte(n.Slack.Attachments), &attachments)
+		assert.NoError(t, err)
+	}
+}

--- a/notifiers/slack.go
+++ b/notifiers/slack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -63,14 +64,14 @@ func (n *slackNotifier) Send(notification Notification, recipient string) error 
 		attachments := make([]slack.Attachment, 0)
 		if notification.Slack.Attachments != "" {
 			if err := json.Unmarshal([]byte(notification.Slack.Attachments), &attachments); err != nil {
-				return err
+				return fmt.Errorf("failed to unmarshal attachments '%s' : %v", notification.Slack.Attachments, err)
 			}
 		}
 
 		blocks := slack.Blocks{}
 		if notification.Slack.Blocks != "" {
 			if err := json.Unmarshal([]byte(notification.Slack.Blocks), &blocks); err != nil {
-				return err
+				return fmt.Errorf("failed to unmarshal blocks '%s' : %v", notification.Slack.Blocks, err)
 			}
 		}
 		msgOptions = append(msgOptions, slack.MsgOptionAttachments(attachments...), slack.MsgOptionBlocks(blocks.BlockSet...))

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -23,6 +23,21 @@ func WithProject(project string) func(app *unstructured.Unstructured) {
 	}
 }
 
+func WithConditions(pairs ...string) func(app *unstructured.Unstructured) {
+	return func(app *unstructured.Unstructured) {
+		var conditions []map[string]string
+		for i := 0; i < len(pairs)-1; i += 2 {
+			conditions = append(conditions, map[string]string{
+				"type":    pairs[i],
+				"message": pairs[i+1],
+			})
+		}
+		app.Object["status"] = map[string]interface{}{
+			"conditions": conditions,
+		}
+	}
+}
+
 func WithObservedAt(t time.Time) func(app *unstructured.Unstructured) {
 	return func(app *unstructured.Unstructured) {
 		ts := t.Format(time.RFC3339)


### PR DESCRIPTION
Closes #65 

PR updates built-in templates so that generated slack attachement is valid json object definition. 