### PR TITLE
Adding Helm v3 getting started notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,3 +53,19 @@ kubectl patch app <my-app> -n argocd -p '{"metadata": {"annotations": {"recipien
 ```
 
 Try syncing and application and get the notification once sync is completed.
+
+## Helm v3 Getting Started
+
+argocd-notifications is now on [Helm Hub](https://hub.helm.sh/charts/argo/argocd-notifications) as a Helm v3 chart, making it even easier to get started as
+installing and configuring happen together:
+
+```shell
+helm repo add argo https://argoproj.github.io/argo-helm
+helm install argo/argocd-notifications --generate-name \
+    --set triggers[0].name=on-sync-succeeded \
+    --set triggers[0].enabled=true \
+    --set secret.notifiers.slack.enabled=true \
+    --set secret.notifiers.slack.token=<my-token>
+```
+
+For more information or to contribute, check out the [argoproj/argo-helm repository](https://github.com/argoproj/argo-helm/tree/master/charts/argocd-notifications).


### PR DESCRIPTION
This PR is meant to facilitate others migrating to using Helm for installing and managing argocd-notifications based on the work done in [argoproj/argo-helm](https://github.com/argoproj/argo-helm/tree/master/charts/argocd-notifications).  However, I kept the original getting started instructions until the project decides to solely support Helm installation or not.

Any feedback is welcome especially as helm/monocular doesn't support displaying Helm v3 instructions yet: https://github.com/helm/monocular/pull/660