### PR TITLE
Run kubernetes deployment as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,8 @@ FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /dist/argocd-notifications /app/argocd-notifications
+
+# User numeric user so that kubernetes can assert that the user id isn't root (0).
+# We are also using the root group (the 0 in 1000:0), it doesn't have any
+# privileges, as opposed to the root user.
+USER 1000:0

--- a/manifests/controller/argocd-notifications-controller-deployment.yaml
+++ b/manifests/controller/argocd-notifications-controller-deployment.yaml
@@ -22,3 +22,5 @@ spec:
           imagePullPolicy: Always
           name: argocd-notifications-controller
       serviceAccountName: argocd-notifications-controller
+      securityContext:
+          runAsNonRoot: true

--- a/manifests/install-bot.yaml
+++ b/manifests/install-bot.yaml
@@ -171,4 +171,6 @@ spec:
         imagePullPolicy: Always
         name: argocd-notifications-controller
         workingDir: /app
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: argocd-notifications-controller

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -90,4 +90,6 @@ spec:
         imagePullPolicy: Always
         name: argocd-notifications-controller
         workingDir: /app
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: argocd-notifications-controller


### PR DESCRIPTION
We don't need to specify `runAsUser` because the USER in the Dockerfile is the numeric user 1000 and kubernetes will be able to assert that the USER isn't root (0).

When you use a non-numeric USER in the Dockerfile, you need to specify `runAsUser` because kubernetes can't make sure that the specified user isn't root just by inspecting the docker image.

But using `runAsUser` isn't desirable because it complicates things, in our case we have a mix of kops(in aws) and openshift clusters and for openshift it injects the `runAsUser` automatically and if it's not in the random range assigned to the namespace, it fails, and the random range for user ids is usually very high (> 1000000000).