### PR TITLE
fix : support HTTP proxy

### DIFF
--- a/notifiers/slack.go
+++ b/notifiers/slack.go
@@ -40,11 +40,8 @@ func NewSlackNotifier(opts SlackOptions) Notifier {
 }
 
 func (n *slackNotifier) Send(notification Notification, recipient string) error {
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: n.opts.InsecureSkipVerify,
-		},
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: n.opts.InsecureSkipVerify}
 	client := &http.Client{
 		Transport: httputil.NewLoggingRoundTripper(transport, log.WithField("notifier", "slack")),
 	}


### PR DESCRIPTION
Fixes #42 

Configure the http client in the `slackNotifier` with the default transport settings.

It's better not to lose the default transport settings when configuring http.Client, because, without default transport settings, we cannot use a proxy to post messages to slack.

Thanks :)