### PR TITLE
fix annotations for tracking notifications have sent.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -288,10 +288,7 @@ func getMapByTrackTrigger(annotations map[string]string, trackTriggerKey string)
 func checkAlreadyNotified(annotations map[string]string, trackTriggerKey string, recipient string) bool {
 	recipientTimestampMap := getMapByTrackTrigger(annotations, trackTriggerKey)
 	_, ok := recipientTimestampMap[recipient]
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }
 
 func insertNotifiedTracking(annotations map[string]string, trackTriggerKey string, recipient string, recipientTimestamp string) {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -75,15 +75,18 @@ func TestSendsNotificationIfTriggered(t *testing.T) {
 	err = ctrl.processApp(app, logEntry)
 
 	assert.NoError(t, err)
-	assert.NotEmpty(t, app.GetAnnotations()[fmt.Sprintf("mock.mock.recipient.%s", recipients.AnnotationPostfix)])
+
+	annotation := app.GetAnnotations()[fmt.Sprintf("mock.%s", recipients.AnnotationPostfix)]
+	assert.NotEmpty(t, annotation)
+	assert.Contains(t, annotation, "mock:recipient")
 }
 
 func TestDoesNotSendNotificationIfAnnotationPresent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	app := NewApp("test", WithAnnotations(map[string]string{
-		recipients.RecipientsAnnotation:                                     "mock:recipient",
-		fmt.Sprintf("mock.mock.recipient.%s", recipients.AnnotationPostfix): time.Now().Format(time.RFC3339),
+		recipients.RecipientsAnnotation:                      "mock:recipient",
+		fmt.Sprintf("mock.%s", recipients.AnnotationPostfix): fmt.Sprintf("mock:recipient=%s\n", time.Now().Format(time.RFC3339)),
 	}))
 	ctrl, trigger, _, err := newController(t, ctx, fake.NewSimpleDynamicClient(runtime.NewScheme(), app))
 	assert.NoError(t, err)
@@ -99,8 +102,8 @@ func TestRemovesAnnotationIfNoTrigger(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	app := NewApp("test", WithAnnotations(map[string]string{
-		recipients.RecipientsAnnotation:                                     "mock:recipient",
-		fmt.Sprintf("mock.mock.recipient.%s", recipients.AnnotationPostfix): time.Now().Format(time.RFC3339),
+		recipients.RecipientsAnnotation:                      "mock:recipient",
+		fmt.Sprintf("mock.%s", recipients.AnnotationPostfix): fmt.Sprintf("mock:recipient=%s\n", time.Now().Format(time.RFC3339)),
 	}))
 	ctrl, trigger, _, err := newController(t, ctx, fake.NewSimpleDynamicClient(runtime.NewScheme(), app))
 	assert.NoError(t, err)
@@ -110,7 +113,7 @@ func TestRemovesAnnotationIfNoTrigger(t *testing.T) {
 	err = ctrl.processApp(app, logEntry)
 
 	assert.NoError(t, err)
-	assert.Empty(t, app.GetAnnotations()[fmt.Sprintf("mock.mock.recipient.%s", recipients.AnnotationPostfix)])
+	assert.Empty(t, app.GetAnnotations()[fmt.Sprintf("mock.%s", recipients.AnnotationPostfix)])
 }
 
 func TestGetRecipients(t *testing.T) {
@@ -148,8 +151,8 @@ func TestUpdatedAnnotationsSavedAsPatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 	app := NewApp("test", WithAnnotations(map[string]string{
-		recipients.RecipientsAnnotation:                                     "mock:recipient",
-		fmt.Sprintf("mock.mock.recipient.%s", recipients.AnnotationPostfix): time.Now().Format(time.RFC3339),
+		recipients.RecipientsAnnotation:                      "mock:recipient",
+		fmt.Sprintf("mock.%s", recipients.AnnotationPostfix): fmt.Sprintf("mock:recipient=%s\n", time.Now().Format(time.RFC3339)),
 	}))
 
 	patchCh := make(chan []byte)
@@ -173,7 +176,7 @@ func TestUpdatedAnnotationsSavedAsPatch(t *testing.T) {
 		patch := map[string]interface{}{}
 		err = json.Unmarshal(patchData, &patch)
 		assert.NoError(t, err)
-		val, ok, err := unstructured.NestedFieldNoCopy(patch, "metadata", "annotations", fmt.Sprintf("mock.mock.recipient.%s", recipients.AnnotationPostfix))
+		val, ok, err := unstructured.NestedFieldNoCopy(patch, "metadata", "annotations", fmt.Sprintf("mock.%s", recipients.AnnotationPostfix))
 		assert.NoError(t, err)
 		assert.True(t, ok)
 		assert.Nil(t, val)

--- a/shared/recipients/annotations_test.go
+++ b/shared/recipients/annotations_test.go
@@ -40,26 +40,3 @@ func TestAnnotationsPatch(t *testing.T) {
 		"key4": pointer.StringPtr("val4"),
 	}, patch)
 }
-
-func TestFormatTriggerRecipientAnnotation(t *testing.T) {
-	tests := []struct {
-		trigger   string
-		recipient string
-		want      string
-	}{
-		{
-			recipient: "slack:channel",
-			trigger:   "on-sync",
-			want:      "on-sync.slack.channel.argocd-notifications.argoproj.io",
-		},
-		{
-			recipient: "email:my@email.com",
-			trigger:   "on-sync",
-			want:      "on-sync.email.my.email.com.argocd-notifications.argoproj.io",
-		},
-	}
-	for _, tt := range tests {
-		got := FormatTriggerRecipientAnnotation(tt.trigger, tt.recipient)
-		assert.Equal(t, tt.want, got)
-	}
-}


### PR DESCRIPTION
fixes: #117

Here is the new format:
```
metadata:
  annotations:
    on-sync-succeeded.argocd-notifications.argoproj.io: |
      slack:general=2020-11-23T17:31:32-08:00
```