### PR TITLE
fix: Argo notifications fails to send notification with "invalid character

### DIFF
--- a/builtin/templates/app-health-degraded.yaml
+++ b/builtin/templates/app-health-degraded.yaml
@@ -21,6 +21,7 @@ slack:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",

--- a/builtin/templates/app-sync-failed.yaml
+++ b/builtin/templates/app-sync-failed.yaml
@@ -21,6 +21,7 @@ slack:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",

--- a/builtin/templates/app-sync-running.yaml
+++ b/builtin/templates/app-sync-running.yaml
@@ -21,6 +21,7 @@ slack:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",

--- a/builtin/templates/app-sync-status-unknown.yaml
+++ b/builtin/templates/app-sync-status-unknown.yaml
@@ -26,6 +26,7 @@ slack:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",

--- a/builtin/templates/app-sync-succeeded.yaml
+++ b/builtin/templates/app-sync-succeeded.yaml
@@ -21,6 +21,7 @@ slack:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",

--- a/manifests/controller/argocd-notifications-cm.yaml
+++ b/manifests/controller/argocd-notifications-cm.yaml
@@ -24,6 +24,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -44,8 +45,9 @@ data:
         \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
         \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
         \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+        not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n
+        \   \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]
+        \   "
     title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
     body: |
@@ -71,6 +73,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -109,6 +112,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -129,8 +133,9 @@ data:
         \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
         \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
         \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+        not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n
+        \   \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]
+        \   "
     title: Application {{.app.metadata.name}} has been successfully synced.
   trigger.on-health-degraded: |
     condition: app.status.health.status == 'Degraded'

--- a/manifests/install-bot.yaml
+++ b/manifests/install-bot.yaml
@@ -111,6 +111,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -131,8 +132,9 @@ data:
         \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
         \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
         \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+        not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n
+        \   \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]
+        \   "
     title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
     body: |
@@ -158,6 +160,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -196,6 +199,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -216,8 +220,9 @@ data:
         \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
         \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
         \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+        not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n
+        \   \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]
+        \   "
     title: Application {{.app.metadata.name}} has been successfully synced.
   trigger.on-health-degraded: |
     condition: app.status.health.status == 'Degraded'

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -67,7 +67,6 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
-          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -83,33 +82,13 @@ data:
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     name: app-sync-failed
     slack:
-      attachments: |-
-        [{
-          "title": "{{ .app.metadata.name}}",
-          "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
-          "color": "#E96D76",
-          "fields": [
-          {
-            "title": "Sync Status",
-            "value": "{{.app.status.sync.status}}",
-            "short": true
-          },
-          {
-            "title": "Repository",
-            "value": "{{.app.spec.source.repoURL}}",
-            "short": true
-          }
-          {{range $index, $c := .app.status.conditions}}
-          {{if not $index}},{{end}}
-          {{if $index}},{{end}}
-          {
-            "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
-            "short": true
-          }
-          {{end}}
-          ]
-        }]
+      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
+        \ \"color\": \"#E96D76\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
+        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
+        \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
+        \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
+        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
+        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
     title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
     body: |
@@ -135,7 +114,6 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
-          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -174,7 +152,6 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
-          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -190,33 +167,13 @@ data:
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     name: app-sync-succeeded
     slack:
-      attachments: |-
-        [{
-          "title": "{{ .app.metadata.name}}",
-          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
-          "color": "#18be52",
-          "fields": [
-          {
-            "title": "Sync Status",
-            "value": "{{.app.status.sync.status}}",
-            "short": true
-          },
-          {
-            "title": "Repository",
-            "value": "{{.app.spec.source.repoURL}}",
-            "short": true
-          }
-          {{range $index, $c := .app.status.conditions}}
-          {{if not $index}},{{end}}
-          {{if $index}},{{end}}
-          {
-            "title": "{{$c.type}}",
-            "value": "{{$c.message}}",
-            "short": true
-          }
-          {{end}}
-          ]
-        }]
+      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
+        \ \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
+        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
+        \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
+        \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
+        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
+        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
     title: Application {{.app.metadata.name}} has been successfully synced.
   trigger.on-health-degraded: |
     condition: app.status.health.status == 'Degraded'

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -67,6 +67,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -87,8 +88,9 @@ data:
         \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
         \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
         \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+        not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n
+        \   \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]
+        \   "
     title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
     body: |
@@ -114,6 +116,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -152,6 +155,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -172,8 +176,9 @@ data:
         \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
         \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
         \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+        not $index}},{{end}}\n  {{if $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n
+        \   \"value\": \"{{$c.message}}\",\n    \"short\": true\n  }\n  {{end}}\n  ]\n}]
+        \   "
     title: Application {{.app.metadata.name}} has been successfully synced.
   trigger.on-health-degraded: |
     condition: app.status.health.status == 'Degraded'

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -67,6 +67,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -82,13 +83,33 @@ data:
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     name: app-sync-failed
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#E96D76\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
-        \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+      attachments: |-
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#E96D76",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": "{{.app.spec.source.repoURL}}",
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          {{if not $index}},{{end}}
+          {{if $index}},{{end}}
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
     title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
     body: |
@@ -114,6 +135,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -152,6 +174,7 @@ data:
           }
           {{range $index, $c := .app.status.conditions}}
           {{if not $index}},{{end}}
+          {{if $index}},{{end}}
           {
             "title": "{{$c.type}}",
             "value": "{{$c.message}}",
@@ -167,13 +190,33 @@ data:
       Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
     name: app-sync-succeeded
     slack:
-      attachments: "[{\n  \"title\": \"{{ .app.metadata.name}}\",\n  \"title_link\":\"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}\",\n
-        \ \"color\": \"#18be52\",\n  \"fields\": [\n  {\n    \"title\": \"Sync Status\",\n
-        \   \"value\": \"{{.app.status.sync.status}}\",\n    \"short\": true\n  },\n  {\n
-        \   \"title\": \"Repository\",\n    \"value\": \"{{.app.spec.source.repoURL}}\",\n
-        \   \"short\": true\n  }\n  {{range $index, $c := .app.status.conditions}}\n  {{if
-        not $index}},{{end}}\n  {\n    \"title\": \"{{$c.type}}\",\n    \"value\": \"{{$c.message}}\",\n
-        \   \"short\": true\n  }\n  {{end}}\n  ]\n}]    "
+      attachments: |-
+        [{
+          "title": "{{ .app.metadata.name}}",
+          "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+          "color": "#18be52",
+          "fields": [
+          {
+            "title": "Sync Status",
+            "value": "{{.app.status.sync.status}}",
+            "short": true
+          },
+          {
+            "title": "Repository",
+            "value": "{{.app.spec.source.repoURL}}",
+            "short": true
+          }
+          {{range $index, $c := .app.status.conditions}}
+          {{if not $index}},{{end}}
+          {{if $index}},{{end}}
+          {
+            "title": "{{$c.type}}",
+            "value": "{{$c.message}}",
+            "short": true
+          }
+          {{end}}
+          ]
+        }]
     title: Application {{.app.metadata.name}} has been successfully synced.
   trigger.on-health-degraded: |
     condition: app.status.health.status == 'Degraded'


### PR DESCRIPTION
fixes #126 
After the fix, slack messages is received when there are multiple elements in `app.status.conditions`

![image](https://user-images.githubusercontent.com/7737306/101105291-ff95e900-3581-11eb-8b7c-fe399d37da86.png)

