### PR TITLE
feat: templates have access to 'recipient' via context variable

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -23,7 +23,7 @@ Each template has access to the following fields:
 - `context` is user defined string map and might include any string keys and values.
 - `serviceType` holds the notification service type name. The field can be used to conditionally
 render service specific fields.
-
+- `recipient` holds the recipient name.
 
 ## Functions
 

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	serviceTypeVarName = "serviceType"
+	recipientVarName   = "recipient"
 )
 
 //go:generate mockgen -destination=./mocks/mocks.go -package=mocks github.com/argoproj-labs/argocd-notifications/pkg API
@@ -50,6 +51,7 @@ func (n *api) Send(vars map[string]interface{}, templates []string, dest service
 		in[k] = vars[k]
 	}
 	in[serviceTypeVarName] = dest.Service
+	in[recipientVarName] = dest.Recipient
 	notification, err := n.templatesService.FormatNotification(in, templates...)
 	if err != nil {
 		return err

--- a/pkg/api_test.go
+++ b/pkg/api_test.go
@@ -13,7 +13,9 @@ import (
 func getConfig(ctrl *gomock.Controller, opts ...func(service *mocks.MockNotificationService)) Config {
 	return Config{
 		Templates: map[string]services.Notification{
-			"my-template": {Body: "hello {{ .foo }}"},
+			"my-template": {
+				Body: "hello {{ .foo }} {{ .serviceType }}:{{ .recipient }}",
+			},
 		},
 		Services: map[string]ServiceFactory{
 			"slack": func() (services.NotificationService, error) {
@@ -32,7 +34,7 @@ func TestSend(t *testing.T) {
 
 	api, err := NewAPI(getConfig(ctrl, func(service *mocks.MockNotificationService) {
 		service.EXPECT().Send(services.Notification{
-			Body:    "hello world",
+			Body:    "hello world slack:my-channel",
 			Webhook: map[string]services.WebhookNotification{},
 		}, services.Destination{
 			Service:   "slack",


### PR DESCRIPTION
Closes #141