### PR TITLE
fix: the on-deployed trigger sends multiple notifications

### DIFF
--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -80,7 +80,7 @@ func (svc *service) Run(triggerName string, vars map[string]interface{}) ([]Cond
 		}
 
 		if condition.OncePer != "" {
-			if oncePer, ok, err := unstructured.NestedFieldNoCopy(vars, strings.Split(condition.OncePer, ".")...); err == nil && !ok {
+			if oncePer, ok, err := unstructured.NestedFieldNoCopy(vars, strings.Split(condition.OncePer, ".")...); err == nil && ok {
 				conditionResult.OncePer = fmt.Sprintf("%v", oncePer)
 			}
 		}

--- a/pkg/triggers/service_test.go
+++ b/pkg/triggers/service_test.go
@@ -57,3 +57,46 @@ func TestRun(t *testing.T) {
 		}}, res)
 	})
 }
+
+func TestRun_OncePerSet(t *testing.T) {
+	revision := "123"
+	svc, err := NewService(map[string][]Condition{
+		"my-trigger": {{
+			When:    "var1 == 'abc'",
+			Send:    []string{"my-template"},
+			OncePer: "revision",
+		}},
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	conditionKey := fmt.Sprintf("%s:[0].%s", revision, hash("var1 == 'abc'"))
+
+	t.Run("Triggered", func(t *testing.T) {
+		res, err := svc.Run("my-trigger", map[string]interface{}{"var1": "abc", "revision": "123"})
+		if assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, []ConditionResult{{
+			Key:       conditionKey,
+			Triggered: true,
+			Templates: []string{"my-template"},
+			OncePer:   revision,
+		}}, res)
+	})
+
+	t.Run("NotTriggered", func(t *testing.T) {
+		res, err := svc.Run("my-trigger", map[string]interface{}{"var1": "bcd"})
+		if assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, []ConditionResult{{
+			Key:       conditionKey,
+			Triggered: false,
+			Templates: []string{"my-template"},
+			OncePer:   revision,
+		}}, res)
+	})
+}


### PR DESCRIPTION
PR fixes the trigger `oncePer` field value extraction

Closes https://github.com/argoproj-labs/argocd-notifications/issues/153