### PR TITLE
feat: oncePeer - Trigger messages only when manifest changes (#156)

### DIFF
--- a/catalog/triggers/on-deployed.yaml
+++ b/catalog/triggers/on-deployed.yaml
@@ -1,4 +1,4 @@
 - when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'
   description: Application is synced and healthy. Triggered once per commit.
   send: [app-deployed]
-  oncePer: app.status.sync.revision
+  oncePer: app.status.operationState.syncResult.revision


### PR DESCRIPTION
This revision changes only if someone run sync operation or manifest changes are detected.

#156 