### PR TITLE
Fix slack example secret

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -32,7 +32,7 @@ kind: Secret
 metadata:
   name: argocd-notifications-secret
 stringData:
-  token: <auth-token>
+  slack-token: <auth-token>
 ```
 
 ## Templates


### PR DESCRIPTION
Based on https://argocd-notifications.readthedocs.io/en/stable/services/overview/#sensitive-data
I believe the example secret is using the wrong key