### PR TITLE
Colourise sync running based on current status

### DIFF
--- a/catalog/install.yaml
+++ b/catalog/install.yaml
@@ -117,7 +117,7 @@ data:
         [{
           "title": "{{ .app.metadata.name}}",
           "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
-          "color": "#0DADEA",
+          "color": {{if eq .app.status.sync.status "OutOfSync"}}"#F4C030"{{else}}"#0DADEA"{{end}},
           "fields": [
           {
             "title": "Sync Status",


### PR DESCRIPTION
Colourise the sync running notification the same as in the gui client, so #F4C030 when it's out of sync