### PR TITLE
feat: Added multiarch builds using GitHub workflows and buildx

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - 'master'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -38,9 +39,33 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - run: docker login docker.pkg.github.com --username $USERNAME --password $PASSWORD
-        env:
-          USERNAME: ${{ secrets.USERNAME }}
-          PASSWORD: ${{ secrets.TOKEN }}
-      - run: make image DOCKER_PUSH=true IMAGE_PREFIX=docker.pkg.github.com/argoproj-labs/argocd-notifications IMAGE_TAG=$(cat ./VERSION)-${GITHUB_SHA::8}
+      - 
+        name: Checkout repo
+        uses: actions/checkout@master
+      - 
+        name: Build image tag
+        run: echo "IMAGE_TAG=$(cat ./VERSION)-${GITHUB_SHA::8}" >> $GITHUB_ENV 
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: docker.pkg.github.com/argoproj-labs/argocd-notifications/argocd-notifications:${{ env.IMAGE_TAG }}
+          file: ./Dockerfile
+          build-args: |
+              IMAGE_TAG=${{ env.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM golang:1.15.3 as builder
+FROM --platform=$BUILDPLATFORM golang:1.15.3 as builder
 
 RUN apt-get update && apt-get install ca-certificates
 
 WORKDIR /src
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 COPY go.mod /src/go.mod
 COPY go.sum /src/go.sum
@@ -11,7 +16,7 @@ RUN go mod download
 
 # Perform the build
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /app/argocd-notifications ./cmd
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /app/argocd-notifications ./cmd
 RUN ln -s /app/argocd-notifications /app/argocd-notifications-backend
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ generate: manifests catalog
 build:
 ifeq ($(RELEASE), true)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o ./dist/argocd-notifications-linux-amd64 ./cmd
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-w -s" -o ./dist/argocd-notifications-linux-arm64 ./cmd
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags="-w -s" -o ./dist/argocd-notifications-linux-arm ./cmd
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-w -s" -o ./dist/argocd-notifications-darwin-amd64 ./cmd
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="-w -s" -o ./dist/argocd-notifications-windows-amd64.exe ./cmd
 else


### PR DESCRIPTION
This PR focuses on creating multiarch images by default (currently `linux/amd64`,`linux/arm64` and `linux/arm`) this can be easily extended to others).

I have only added pushing to `docker.pkg.github.com` as that was what existed in the existing `ci.yaml` file, but it can be trivially extended on request to also push to DockerHub automatically as part of the workflow (would require a username and password secret to be added to the repo for DockerHub).

As it stands, this PR uses Docker Buildx and Qemu to build a common builder image (based on the arch of the platform it is building on) and then creates layers for each target OS and target arch [specified here](https://github.com/argoproj-labs/argocd-notifications/compare/master...mylesagray:master#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR66)

This removed the need to use the Makefile for release if so desired and can be run completely through GH workflows.