### PR TITLE
Migrated from deprecated to GitHub Packages to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,12 +52,18 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Login to Registry
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
         with:
-          registry: docker.pkg.github.com
-          username: ${{ secrets.USERNAME }}
-          password: ${{ secrets.TOKEN }}
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_PAT }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
@@ -65,7 +71,11 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/arm
           push: true
-          tags: docker.pkg.github.com/argoproj-labs/argocd-notifications/argocd-notifications:${{ env.IMAGE_TAG }}
+          tags: |
+            argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
+            argoproj-labs/argocd-notifications:latest
+            ghcr.io/argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
+            ghcr.io/argoproj-labs/argocd-notifications:latest
           file: ./Dockerfile
           build-args: |
               IMAGE_TAG=${{ env.IMAGE_TAG }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,12 +59,6 @@ jobs:
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_PAT }}
       -
-        name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -72,9 +66,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm
           push: true
           tags: |
-            argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
-            argoproj-labs/argocd-notifications:latest
-            ghcr.io/argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
             ghcr.io/argoproj-labs/argocd-notifications:latest
           file: ./Dockerfile
           build-args: |


### PR DESCRIPTION
Per comments in #184 I have migrated the CI workflow from the deprecated GitHub Packages to the new GitHub Container Registry.

Note that images will be tagged the same way they are today - and an additional `:latest` tag will be added to each push as well.

This PR will need a few things done before it is merged:

- Two secrets need to be created on the GH repo:
- GH_USERNAME - a user with ownership over the argoproj-labs GH Org
- GH_PAT - a personal access token with `package:read`, `package:write` and `package:delete` permissions. more here: <https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry>

Once those pre-reqs are met this is safe to merge and should auto build and push fresh multi-arch images to both repos!

/cc @alexmt 