### PR TITLE
Feat: Automated release to GitHub and GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,12 @@ jobs:
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_PAT }}
       -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -67,6 +73,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/argoproj-labs/argocd-notifications:latest
+            argoproj-labs/argocd-notifications:latest
           file: ./Dockerfile
           build-args: |
               IMAGE_TAG=${{ env.IMAGE_TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,9 +65,7 @@ jobs:
           push: true
           tags: |
             argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
-            argoproj-labs/argocd-notifications:latest
             ghcr.io/argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
-            ghcr.io/argoproj-labs/argocd-notifications:latest
           file: ./Dockerfile
           build-args: |
               IMAGE_TAG=${{ env.IMAGE_TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.15.3'
+      - run: make test
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          args: --timeout 5m
+        env:
+          GOROOT: ""
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} #required
+          file: ./coverage.out
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout repo
+        uses: actions/checkout@master
+      - 
+        name: Build image tag
+        run: echo "IMAGE_TAG=v$(cat ./VERSION)" >> $GITHUB_ENV 
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_PAT }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: |
+            argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
+            argoproj-labs/argocd-notifications:latest
+            ghcr.io/argoproj-labs/argocd-notifications:${{ env.IMAGE_TAG }}
+            ghcr.io/argoproj-labs/argocd-notifications:latest
+          file: ./Dockerfile
+          build-args: |
+              IMAGE_TAG=${{ env.IMAGE_TAG }}


### PR DESCRIPTION
As per discussion in #190  - this adds support for automatic releases to DockerHub and GHCR.

This workflow can only be invoked via the "Run workflow" in the GitHub Actions UI.

It will publish images with tags reflecting what is in `Makefile` - the output of "v" + `VERSION` file and will tag whatever image that is with the `latest` tag as well.

I have noted on DockerHub that the image tags are of format `v1.0.0` and this PR reflects that - would we rather a different tagging scheme or is this okay? /cc @alexmt for 👀 