### PR TITLE
fix: merging secrets into service config not working (fixes #208)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/whilp/git-urls v0.0.0-20191001220047-6db9661140c0
 	gomodules.xyz/notify v0.1.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -57,75 +57,82 @@ func TestReplaceStringSecret_KeyMissing(t *testing.T) {
 	assert.Equal(t, "hello $secret-value", val)
 }
 
-func TestReplaceServiceConfigSecret(t *testing.T) {
-	tests := []struct {
-		config map[string]interface{}
-		secret map[string][]byte
-		want   map[string]interface{}
-	}{
-		{
-			config: map[string]interface{}{
-				"url": "$endpoint",
-				"headers": []map[string]interface{}{
-					{
-						"name":  "Authorization",
-						"value": "Bearer $secret-value",
-					},
-				},
-			},
-			secret: map[string][]byte{
-				"endpoint":     []byte("https://example.com"),
-				"secret-value": []byte("token"),
-			},
-			want: map[string]interface{}{
-				"url": "https://example.com",
-				"headers": []map[string]interface{}{
-					{
-						"name":  "Authorization",
-						"value": "Bearer token",
-					},
-				},
-			},
-		},
-		{
-			config: map[string]interface{}{
-				"apiUrl": "$endpoint",
-				"apiKeys": map[string]interface{}{
-					"first-team":  "$first-team-secret",
-					"second-team": "$second-team-secret",
-				},
-			},
-			secret: map[string][]byte{
-				"first-team-secret":  []byte("first-token"),
-				"second-team-secret": []byte("second-token"),
-			},
-			want: map[string]interface{}{
-				"apiUrl": "$endpoint",
-				"apiKeys": map[string]interface{}{
-					"first-team":  "first-token",
-					"second-team": "second-token",
-				},
-			},
-		},
-		{
-			config: map[string]interface{}{
-				"appID":          12345,
-				"privateKey":     "$github-privateKey",
-				"installationID": 67890,
-			},
-			secret: map[string][]byte{
-				"github-privateKey": []byte("privateKey"),
-			},
-			want: map[string]interface{}{
-				"appID":          12345,
-				"privateKey":     "privateKey",
-				"installationID": 67890,
-			},
+func TestReplaceServiceConfigSecrets_WithBasicWebhook_ReplacesSecrets(t *testing.T) {
+	input := `url: $endpoint
+headers:
+  - name: Authorization
+    value: Bearer $secret-value
+`
+
+	secrets := v1.Secret{
+		Data: map[string][]byte{
+			"endpoint":     []byte("https://example.com"),
+			"secret-value": []byte("token"),
 		},
 	}
 
-	for _, tt := range tests {
-		result := replaceServiceConfigSecret(tt.config, tt.secret)
-		assert.Equal(t, tt.want, result)
+	expected := `url: https://example.com
+headers:
+  - name: Authorization
+    value: Bearer token
+`
+
+	result, err := replaceServiceConfigSecrets(input, &secrets)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(result))
+}
+
+func TestReplaceServiceConfigSecrets_WithMapOfSecrets_ReplacesSecrets(t *testing.T) {
+	input := `apiUrl: $api-url
+apiKeys:
+  first-team: $first-team-secret
+  second-team: $second-team-secret
+`
+
+	secrets := v1.Secret{
+		Data: map[string][]byte{
+			"first-team-secret":  []byte("first-token"),
+			"second-team-secret": []byte("second-token"),
+		},
 	}
+
+	expected := `apiUrl: $api-url
+apiKeys:
+    first-team: first-token
+    second-team: second-token
+`
+
+	result, err := replaceServiceConfigSecrets(input, &secrets)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(result))
+}
+
+func TestReplaceServiceConfigSecrets_WithMultilineSecret_ReplacesSecrets(t *testing.T) {
+	input := `appID: 12345
+privateKey: $github-privateKey
+installationID: 67890
+`
+
+	secrets := v1.Secret{
+		Data: map[string][]byte{
+			"github-privateKey":  []byte("A\nValue\nOn\nMultiple\nLines"),
+		},
+	}
+
+	expected := `appID: 12345
+privateKey: |-
+    A
+    Value
+    On
+    Multiple
+    Lines
+installationID: 67890
+`
+
+	result, err := replaceServiceConfigSecrets(input, &secrets)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(result))
 }


### PR DESCRIPTION
This addresses an issue introduced in #180 where the types in the type switch during YAML Unmarshal/Marshal were not actually what you would see in practice. The tests used the same incorrect types so this was not caught.

This patch changes the approach to walk the actual YAML AST (provided by yaml.v3 package) and replace any strings containing secrets with the secret values. Tests are clarified to show multiple line strings working properly.

@alexmt
cc @joshbranham