### PR TITLE
support mattermost integration

### DIFF
--- a/docs/services/mattermost.md
+++ b/docs/services/mattermost.md
@@ -1,0 +1,78 @@
+# Mattermost
+
+## Parameters
+
+* `apiURL` - the server url, e.g. https://mattermost.example.com
+* `token` - the bot token
+* `insecureSkipVerify` - optional bool, true or false
+
+## Configuration
+
+1. Create a bot account and copy token after creating it
+![1](https://user-images.githubusercontent.com/18019529/111499520-62ed0500-8786-11eb-88b0-d0aade61fed4.png)
+2. Invite team
+![2](https://user-images.githubusercontent.com/18019529/111500197-1229dc00-8787-11eb-98e5-587ee36c94a9.png)
+3. Store token in `argocd-notifications-secret` Secret and configure Mattermost integration
+in `argocd-notifications-cm` ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+data:
+  service.mattermost: |
+    apiURL: <api-url>
+    token: $mattermost-token
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+stringData:
+  mattermost-token: token
+```
+
+4. Copy channel id
+![4](https://user-images.githubusercontent.com/18019529/111501289-333efc80-8788-11eb-9731-8353170cd73a.png)
+
+5. Create subscription for your Mattermost integration
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    notifications.argoproj.io/subscribe.<trigger-name>.mattermost: <channel-id>
+```
+
+## Templates
+
+![](https://user-images.githubusercontent.com/18019529/111502636-5fa74880-8789-11eb-97c5-5eac22c00a37.png)
+
+You can reuse the template of slack.  
+Mattermost is compatible with attachments of Slack. See [Mattermost Integration Guide](https://docs.mattermost.com/developer/message-attachments.html).
+
+```yaml
+template.app-deployed: |
+  message: |
+    Application {{.app.metadata.name}} is now running new version of deployments manifests.
+  mattermost:
+    attachments: |
+      [{
+        "title": "{{.app.metadata.name}}",
+        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+        "color": "#18be52",
+        "fields": [{
+          "title": "Sync Status",
+          "value": "{{.app.status.sync.status}}",
+          "short": true
+        }, {
+          "title": "Repository",
+          "value": "{{.app.spec.source.repoURL}}",
+          "short": true
+        }]
+      }]
+```

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -18,14 +18,13 @@ service configuration using `$<secret-key>` format. For example `$slack-token` r
 
 ## Custom Names
 
-Service custom names allow configuring two instances of the same service type. For example, in addition to slack, you might register slack compatible service
-that leverages [Mattermost](https://mattermost.com/):
+Service custom names allow configuring two instances of the same service type.
 
 ```yaml
-  #  Slack based notifier with name mattermost
-  service.slack.mattermost: |
-    apiURL: https://my-mattermost-url.com/api
-    token: $slack-token
+  service.slack.workspace1: |
+    token: $slack-token-workspace1
+  service.slack.workspace2: |
+    token: $slack-token-workspace2
 ```
 
 ```yaml
@@ -33,7 +32,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    notifications.argoproj.io/subscribe.on-sync-succeeded.mattermost: my-channel
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: my-channel
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace2: my-channel
 ```
 
 ## Service Types
@@ -41,6 +41,7 @@ metadata:
 * [Email](./email.md)
 * [GitHub](./github.md)
 * [Slack](./slack.md)
+* [Mattermost](./mattermost.md)
 * [Opsgenie](./opsgenie.md)
 * [Grafana](./grafana.md)
 * [Webhook](./webhook.md)

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -33,7 +33,7 @@ metadata:
   name: argocd-notifications-cm
 data:
   service.slack: |
-    apiURL: <url>                 # optional URL, e.g. https://my-mattermost-url.com/api
+    apiURL: <url>                 # optional URL, e.g. https://example.com/api
     token: $slack-token
     username: <override-username> # optional username
     icon: <override-icon> # optional icon for the message (supports both emoij and url notation)

--- a/pkg/services/mattermost.go
+++ b/pkg/services/mattermost.go
@@ -1,0 +1,100 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	texttemplate "text/template"
+
+	log "github.com/sirupsen/logrus"
+
+	httputil "github.com/argoproj-labs/argocd-notifications/pkg/util/http"
+)
+
+type MattermostNotification struct {
+	Attachments string `json:"attachments,omitempty"`
+}
+
+func (n *MattermostNotification) GetTemplater(name string, f texttemplate.FuncMap) (Templater, error) {
+	mattermostAttachments, err := texttemplate.New(name).Funcs(f).Parse(n.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	return func(notification *Notification, vars map[string]interface{}) error {
+		if notification.Mattermost == nil {
+			notification.Mattermost = &MattermostNotification{}
+		}
+		var mattermostAttachmentsData bytes.Buffer
+		if err := mattermostAttachments.Execute(&mattermostAttachmentsData, vars); err != nil {
+			return err
+		}
+
+		notification.Mattermost.Attachments = mattermostAttachmentsData.String()
+		return nil
+	}, nil
+}
+
+type MattermostOptions struct {
+	ApiURL             string `json:"apiURL"`
+	Token              string `json:"token"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+}
+
+type mattermostService struct {
+	opts MattermostOptions
+}
+
+func NewMattermostService(opts MattermostOptions) NotificationService {
+	return &mattermostService{opts: opts}
+}
+
+func (m *mattermostService) Send(notification Notification, dest Destination) error {
+	transport := httputil.NewTransport(m.opts.ApiURL, m.opts.InsecureSkipVerify)
+	client := &http.Client{
+		Transport: httputil.NewLoggingRoundTripper(transport, log.WithField("service", "mattermost")),
+	}
+
+	attachments := []interface{}{}
+	if notification.Mattermost != nil {
+		if notification.Mattermost.Attachments != "" {
+			if err := json.Unmarshal([]byte(notification.Mattermost.Attachments), &attachments); err != nil {
+				return fmt.Errorf("failed to unmarshal attachments '%s' : %v", notification.Mattermost.Attachments, err)
+			}
+		}
+	}
+
+	body := map[string]interface{}{
+		"channel_id": dest.Recipient,
+		"message":    notification.Message,
+		"props": map[string]interface{}{
+			"attachments": attachments,
+		},
+	}
+	b, _ := json.Marshal(body)
+
+	req, err := http.NewRequest(http.MethodPost, m.opts.ApiURL+"/api/v4/posts", bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", m.opts.Token))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to request: %v", err)
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read body: %v", err)
+	}
+
+	if res.StatusCode/100 != 2 {
+		return fmt.Errorf("request to %s has failed with error code %d : %s", body, res.StatusCode, string(data))
+	}
+
+	return nil
+}

--- a/pkg/services/mattermost_test.go
+++ b/pkg/services/mattermost_test.go
@@ -1,0 +1,97 @@
+package services
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSend_Mattermost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := ioutil.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		assert.JSONEq(t, `{
+			"channel_id": "channel",
+			"message": "message",
+			"props": {
+				"attachments": [{
+					"title": "title",
+					"title_link": "https://argocd.example.com/applications/argocd-notifications",
+					"color": "#18be52",
+					"fields": [{
+						"title": "Sync Status",
+						"value": "Synced",
+						"short": true
+					}, {
+						"title": "Repository",
+						"value": "https://example.com",
+						"short": true
+					}]
+				}]
+			}
+		}`, string(b))
+	}))
+	defer ts.Close()
+
+	service := NewMattermostService(MattermostOptions{
+		ApiURL:             ts.URL,
+		Token:              "token",
+		InsecureSkipVerify: true,
+	})
+	err := service.Send(Notification{
+		Message: "message",
+		Mattermost: &MattermostNotification{
+			Attachments: `[{
+				"title": "title",
+				"title_link": "https://argocd.example.com/applications/argocd-notifications",
+				"color": "#18be52",
+				"fields": [{
+					"title": "Sync Status",
+					"value": "Synced",
+					"short": true
+				}, {
+					"title": "Repository",
+					"value": "https://example.com",
+					"short": true
+				}]
+			}]`,
+		},
+	}, Destination{
+		Service:   "mattermost",
+		Recipient: "channel",
+	})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+}
+
+func TestGetTemplater_Mattermost(t *testing.T) {
+	n := Notification{
+		Mattermost: &MattermostNotification{
+			Attachments: "{{.foo}}",
+		},
+	}
+	templater, err := n.GetTemplater("", template.FuncMap{})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var notification Notification
+	err = templater(&notification, map[string]interface{}{
+		"foo": "hello",
+	})
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "hello", notification.Mattermost.Attachments)
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -11,13 +11,14 @@ import (
 )
 
 type Notification struct {
-	Message  string                `json:"message,omitempty"`
-	Email    *EmailNotification    `json:"email,omitempty"`
-	Slack    *SlackNotification    `json:"slack,omitempty"`
-	Teams    *TeamsNotification    `json:"teams,omitempty"`
-	Webhook  WebhookNotifications  `json:"webhook,omitempty"`
-	Opsgenie *OpsgenieNotification `json:"opsgenie,omitempty"`
-	GitHub   *GitHubNotification   `json:"github,omitempty"`
+	Message    string                  `json:"message,omitempty"`
+	Email      *EmailNotification      `json:"email,omitempty"`
+	Slack      *SlackNotification      `json:"slack,omitempty"`
+	Mattermost *MattermostNotification `json:"mattermost,omitempty"`
+	Teams      *TeamsNotification      `json:"teams,omitempty"`
+	Webhook    WebhookNotifications    `json:"webhook,omitempty"`
+	Opsgenie   *OpsgenieNotification   `json:"opsgenie,omitempty"`
+	GitHub     *GitHubNotification     `json:"github,omitempty"`
 }
 
 // Destination holds notification destination details
@@ -30,6 +31,9 @@ func (n *Notification) GetTemplater(name string, f texttemplate.FuncMap) (Templa
 	var sources []TemplaterSource
 	if n.Slack != nil {
 		sources = append(sources, n.Slack)
+	}
+	if n.Mattermost != nil {
+		sources = append(sources, n.Mattermost)
 	}
 	if n.Email != nil {
 		sources = append(sources, n.Email)
@@ -73,6 +77,12 @@ func NewService(serviceType string, optsData []byte) (NotificationService, error
 			return nil, err
 		}
 		return NewSlackService(opts), nil
+	case "mattermost":
+		var opts MattermostOptions
+		if err := yaml.Unmarshal(optsData, &opts); err != nil {
+			return nil, err
+		}
+		return NewMattermostService(opts), nil
 	case "grafana":
 		var opts GrafanaOptions
 		if err := yaml.Unmarshal(optsData, &opts); err != nil {


### PR DESCRIPTION
Signed-off-by: Ryota Sakamoto <sakamo.ryota+github@gmail.com>

refs: #176

I don't use [mattermost/mattermost-server model/client4.go](https://github.com/mattermost/mattermost-server/blob/master/model/client4.go), because it is too large to use library.
