### PR TITLE
docs: fix missing mattermost nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - services/email.md
     - services/github.md
     - services/slack.md
+    - services/mattermost.md
     - services/opsgenie.md
     - services/grafana.md
     - services/telegram.md


### PR DESCRIPTION
Signed-off-by: Ryota Sakamoto <sakamo.ryota+github@gmail.com>