### PR TITLE
Fix yaml syntax for defaultTriggers in ConfigMap

### DIFF
--- a/docs/argocd-notifications-cm.yaml
+++ b/docs/argocd-notifications-cm.yaml
@@ -37,7 +37,7 @@ data:
         }]
 
   # Holds list of triggers that are used by default if trigger is not specified explicitly in the subscription
-  defaultTriggers:
+  defaultTriggers: |
     - on-sync-status-unknown
 
   # Notification services are used to deliver message.

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -75,7 +75,7 @@ metadata:
   name: argocd-notifications-cm
 data:
   # Holds list of triggers that are used by default if trigger is not specified explicitly in the subscription
-  defaultTriggers:
+  defaultTriggers: |
     - on-sync-status-unknown
 ```
 


### PR DESCRIPTION
Signed-off-by: toVersus <toversus2357@gmail.com>

When I tried to add default triggers following the instruction described in docs (#221), I got an error:

```bash
$ cat <<EOF > argocd-notifications-cm.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-notifications-cm
data:
  # Holds list of triggers that are used by default if trigger is not specified explicitly in the subscription
  defaultTriggers:
    - on-sync-status-unknown
EOF

$ kubectl diff -n default -f argocd-notifications-cm.yaml
Error from server (BadRequest): ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found [, error found in #10 byte of ...|riggers":["on-sync-s|..., bigger context ...|{"apiVersion":"v1","data":{"defaultTriggers":["on-sync-status-unknown"]},"kind":"ConfigMap","met|...
```

With this fix, a ConfigMap can be created without any errors and it works as expected:

```bash
$ cat <<EOF > argocd-notifications-cm.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-notifications-cm
data:
  # Holds list of triggers that are used by default if trigger is not specified explicitly in the subscription
  defaultTriggers: |
    - on-sync-status-unknown
EOF

$ kubectl diff -n default -f argocd-notifications-cm.yaml
diff -u -N /tmp/LIVE-060868910/v1.ConfigMap.default.argocd-notifications-cm /tmp/MERGED-557809333/v1.ConfigMap.default.argocd-notifications-cm
--- /tmp/LIVE-060868910/v1.ConfigMap.default.argocd-notifications-cm	2021-03-26 10:40:53.316318114 +0900
+++ /tmp/MERGED-557809333/v1.ConfigMap.default.argocd-notifications-cm	2021-03-26 10:40:53.381322773 +0900
@@ -0,0 +1,11 @@
+apiVersion: v1
+data:
+  defaultTriggers: |
+    - on-sync-status-unknown
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2021-03-26T01:40:53Z"
+  name: argocd-notifications-cm
+  namespace: default
+  selfLink: /api/v1/namespaces/default/configmaps/argocd-notifications-cm
+  uid: 3e610446-4ffe-4f83-bce1-d2a69ec0ab2c
```
