### PR TITLE
Update install manifests to v1.1.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,13 +11,13 @@ So you can just use them instead of reinventing new ones.
 * Install Argo CD Notifications
 
 ```
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/release-1.0/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.1.0/manifests/install.yaml
 ```
 
 * Install Triggers and Templates from the catalog
 
 ```
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/release-1.0/catalog/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.1.0/catalog/install.yaml
 ```
 
 * Add Email username and password token to `argocd-notifications-secret` secret
@@ -73,21 +73,21 @@ argocd-notification manifests can also be installed using [Kustomize](https://ku
 argocd-notifications, we recommended saving a tagged release of the `install.yaml`:
 
 ```shell
-curl -o argocd-notifications-v1.0.2-install.yaml https://github.com/argoproj-labs/argocd-notifications/blob/v1.0.2/manifests/install.yaml
+curl -o argocd-notifications-v1.1.0-install.yaml https://github.com/argoproj-labs/argocd-notifications/blob/v1.1.0/manifests/install.yaml
 ```
 
 The tagged release should then be included in a `kustomization.yaml`:
 ```yaml
 namespace: argocd
 resources:
-- argocd-notifications-v1.0.2-install.yaml
+- argocd-notifications-v1.1.0-install.yaml
 ```
 
 If you would like to also install Triggers and Templates from the Catalog, we recommend
 saving a tagged release of the catalog `install.yaml`:
 
 ```shell
-curl -o argocd-notifications-catalog-v1.0.2-install.yaml https://github.com/argoproj-labs/argocd-notifications/blob/v1.0.2/catalog/install.yaml
+curl -o argocd-notifications-catalog-v1.1.0-install.yaml https://github.com/argoproj-labs/argocd-notifications/blob/v1.1.0/catalog/install.yaml
 ```
 
 The tagged release should then be patched into the base argocd-notifications install
@@ -96,7 +96,7 @@ manifest in your `kustomization.yaml`:
 ```yaml
 namespace: argocd
 resources:
-- argocd-notifications-v1.0.2-install.yaml
+- argocd-notifications-v1.1.0-install.yaml
 patchesStrategicMerge:
-- argocd-notifications-catalog-v1.0.2-install.yaml
+- argocd-notifications-catalog-v1.1.0-install.yaml
 ```


### PR DESCRIPTION
Update the Getting Started documentation to use the v1.1.0 install manifests, as opposed to the old v1.0.2 manifests.