### PR TITLE
allow configmap/secret list verb

### DIFF
--- a/manifests/controller/argocd-notifications-controller-role.yaml
+++ b/manifests/controller/argocd-notifications-controller-role.yaml
@@ -16,14 +16,20 @@ rules:
   - patch
 - apiGroups:
   - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
   resourceNames:
   - argocd-notifications-cm
   resources:
   - configmaps
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resourceNames:
@@ -32,5 +38,3 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch

--- a/manifests/install-bot.yaml
+++ b/manifests/install-bot.yaml
@@ -52,14 +52,20 @@ rules:
   - patch
 - apiGroups:
   - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
   resourceNames:
   - argocd-notifications-cm
   resources:
   - configmaps
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resourceNames:
@@ -68,8 +74,6 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -21,14 +21,20 @@ rules:
   - patch
 - apiGroups:
   - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
   resourceNames:
   - argocd-notifications-cm
   resources:
   - configmaps
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resourceNames:
@@ -37,8 +43,6 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
allow the argocd-notifications-controller to list and watch configmaps and secrets, so it can refresh stale resources being watched
(noticed it is still throwing warnings without the namespace wide watch permission)

I believe this still honors the original issue by only allowing get permissions on the argocd-notifications-controller owned configmap and secret, instead of all configmaps and secrets in the same namespace.

fixes #237 