### PR TITLE
docs: teams nav is missing

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - services/mattermost.md
     - services/opsgenie.md
     - services/grafana.md
+    - services/teams.md
     - services/telegram.md
     - services/webhook.md
   - catalog.md


### PR DESCRIPTION
Signed-off-by: Ryota Sakamoto <sakamo.ryota+github@gmail.com>