### PR TITLE
feat. support teams theme color templating

### DIFF
--- a/catalog/install.yaml
+++ b/catalog/install.yaml
@@ -90,6 +90,7 @@ data:
             "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
           }]
         }]
+      themeColor: '#000080'
       title: New version of an application {{.app.metadata.name}} is up and running.
   template.app-health-degraded: |
     email:
@@ -161,6 +162,7 @@ data:
             "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
           }]
         }]
+      themeColor: '#FF0000'
       title: Application {{.app.metadata.name}} has degraded.
   template.app-sync-failed: |
     email:
@@ -236,6 +238,7 @@ data:
             "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
           }]
         }]
+      themeColor: '#FF0000'
       title: Failed to sync application {{.app.metadata.name}}.
   template.app-sync-running: |
     email:
@@ -462,6 +465,7 @@ data:
             "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
           }]
         }]
+      themeColor: '#000080'
       title: Application {{.app.metadata.name}} has been successfully synced
   trigger.on-created: |
     - description: Application is created.

--- a/catalog/templates/app-deployed.yaml
+++ b/catalog/templates/app-deployed.yaml
@@ -36,6 +36,7 @@ slack:
           ]
         }]
 teams:
+    themeColor: "#000080"
     title: New version of an application {{.app.metadata.name}} is up and running.
     facts: |
         [{

--- a/catalog/templates/app-health-degraded.yaml
+++ b/catalog/templates/app-health-degraded.yaml
@@ -32,6 +32,7 @@ slack:
           ]
         }]
 teams:
+    themeColor: "#FF0000"
     title: Application {{.app.metadata.name}} has degraded.
     facts: |
         [{

--- a/catalog/templates/app-sync-failed.yaml
+++ b/catalog/templates/app-sync-failed.yaml
@@ -32,6 +32,7 @@ slack:
           ]
         }]
 teams:
+    themeColor: "#FF0000"
     title: Failed to sync application {{.app.metadata.name}}.
     facts: |
         [{

--- a/catalog/templates/app-sync-succeeded.yaml
+++ b/catalog/templates/app-sync-succeeded.yaml
@@ -32,6 +32,7 @@ slack:
           ]
         }]
 teams:
+    themeColor: "#000080"
     title: Application {{.app.metadata.name}} has been successfully synced
     facts: |
         [{

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -112,6 +112,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
+  themeColor: '#000080'
   title: New version of an application {{.app.metadata.name}} is up and running.
 
 ```
@@ -187,6 +188,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
+  themeColor: '#FF0000'
   title: Application {{.app.metadata.name}} has degraded.
 
 ```
@@ -266,6 +268,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
+  themeColor: '#FF0000'
   title: Failed to sync application {{.app.metadata.name}}.
 
 ```
@@ -504,6 +507,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
+  themeColor: '#000080'
   title: Application {{.app.metadata.name}} has been successfully synced
 
 ```

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -112,7 +112,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: '#000080'
+  themeColor: "#000080"
   title: New version of an application {{.app.metadata.name}} is up and running.
 
 ```
@@ -188,7 +188,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: '#FF0000'
+  themeColor: "#FF0000"
   title: Application {{.app.metadata.name}} has degraded.
 
 ```
@@ -268,7 +268,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: '#FF0000'
+  themeColor: "#FF0000"
   title: Failed to sync application {{.app.metadata.name}}.
 
 ```
@@ -507,7 +507,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: '#000080'
+  themeColor: "#000080"
   title: Application {{.app.metadata.name}} has been successfully synced
 
 ```

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -112,7 +112,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: "#000080"
+  themeColor: '#000080'
   title: New version of an application {{.app.metadata.name}} is up and running.
 
 ```
@@ -188,7 +188,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: "#FF0000"
+  themeColor: '#FF0000'
   title: Application {{.app.metadata.name}} has degraded.
 
 ```
@@ -268,7 +268,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: "#FF0000"
+  themeColor: '#FF0000'
   title: Failed to sync application {{.app.metadata.name}}.
 
 ```
@@ -507,7 +507,7 @@ teams:
         "uri":"{{.app.spec.source.repoURL | call .repo.RepoURLToHTTPS}}"
       }]
     }]
-  themeColor: "#000080"
+  themeColor: '#000080'
   title: Application {{.app.metadata.name}} has been successfully synced
 
 ```

--- a/docs/services/teams.md
+++ b/docs/services/teams.md
@@ -21,7 +21,7 @@ metadata:
   name: argocd-notifications-cm
 data:
   service.teams: |
-    recipientUrls: 
+    recipientUrls:
       channelName: $channel-teams-url
 ```
 
@@ -96,4 +96,16 @@ template.app-sync-succeeded: |
         "name": "Repository",
         "value": "{{.app.spec.source.repoURL}}"
       }]
+```
+
+### theme color field
+
+You can set theme color as hex string for the message.
+
+![](https://user-images.githubusercontent.com/1164159/114864810-0718a900-9e24-11eb-8127-8d95da9544c1.png)
+
+```yaml
+template.app-sync-succeeded: |
+  teams:
+    themeColor: "#000080"
 ```

--- a/docs/services/teams.md
+++ b/docs/services/teams.md
@@ -48,11 +48,12 @@ metadata:
 
 ![](https://user-images.githubusercontent.com/18019529/114271500-9d2b8880-9a4c-11eb-85c1-f6935f0431d5.png)
 
-Notification templates can be customized to leverage teams message sections, facts and potentialAction [feature](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).
+Notification templates can be customized to leverage teams message sections, facts, themeColor, and potentialAction [feature](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).
 
 ```yaml
 template.app-sync-succeeded: |
   teams:
+    themeColor: "#000080"
     sections: |
       [{
         "facts": [

--- a/pkg/services/teams.go
+++ b/pkg/services/teams.go
@@ -16,6 +16,7 @@ type TeamsNotification struct {
 	Template        string `json:"template,omitempty"`
 	Title           string `json:"title,omitempty"`
 	Text            string `json:"text,omitempty"`
+	ThemeColor      string `json:"themeColor,omitempty"`
 	Facts           string `json:"facts,omitempty"`
 	Sections        string `json:"sections,omitempty"`
 	PotentialAction string `json:"potentialAction,omitempty"`
@@ -35,6 +36,11 @@ func (n *TeamsNotification) GetTemplater(name string, f texttemplate.FuncMap) (T
 	text, err := texttemplate.New(name).Funcs(f).Parse(n.Text)
 	if err != nil {
 		return nil, fmt.Errorf("error in '%s' teams.text : %w", name, err)
+	}
+
+	themeColor, err := texttemplate.New(name).Funcs(f).Parse(n.ThemeColor)
+	if err != nil {
+		return nil, fmt.Errorf("error in '%s' teams.themeColor: %w", name, err)
 	}
 
 	facts, err := texttemplate.New(name).Funcs(f).Parse(n.Facts)
@@ -79,6 +85,14 @@ func (n *TeamsNotification) GetTemplater(name string, f texttemplate.FuncMap) (T
 		}
 		if val := textBuff.String(); val != "" {
 			notification.Teams.Text = val
+		}
+
+		var themeColorBuff bytes.Buffer
+		if err := themeColor.Execute(&themeColorBuff, vars); err != nil {
+			return err
+		}
+		if val := themeColorBuff.String(); val != "" {
+			notification.Teams.ThemeColor = val
 		}
 
 		var factsData bytes.Buffer
@@ -177,6 +191,10 @@ func teamsNotificationToMessage(n Notification) (*teamsMessage, error) {
 		message.Text = n.Teams.Text
 	}
 
+	if n.Teams.ThemeColor != "" {
+		message.ThemeColor = n.Teams.ThemeColor
+	}
+
 	if n.Teams.Sections != "" {
 		unmarshalledSections := make([]teamsSection, 2)
 		err := json.Unmarshal([]byte(n.Teams.Sections), &unmarshalledSections)
@@ -234,6 +252,7 @@ type teamsMessage struct {
 	Context         string         `json:"context"`
 	Title           string         `json:"title"`
 	Text            string         `json:"text"`
+	ThemeColor      string         `json:"themeColor,omitempty"`
 	PotentialAction []teamsAction  `json:"potentialAction,omitempty"`
 	Sections        []teamsSection `json:"sections,omitempty"`
 }

--- a/pkg/services/teams_test.go
+++ b/pkg/services/teams_test.go
@@ -20,6 +20,7 @@ func TestGetTemplater_Teams(t *testing.T) {
 			Facts:           "facts {{.value}}",
 			Sections:        "sections {{.value}}",
 			PotentialAction: "actions {{.value}}",
+			ThemeColor:      "theme color {{.value}}",
 		},
 	}
 
@@ -47,6 +48,7 @@ func TestGetTemplater_Teams(t *testing.T) {
 	assert.Equal(t, notification.Teams.Sections, "sections value")
 	assert.Equal(t, notification.Teams.Facts, "facts value")
 	assert.Equal(t, notification.Teams.PotentialAction, "actions value")
+	assert.Equal(t, notification.Teams.ThemeColor, "theme color value")
 }
 
 func TestTeams_DefaultMessage(t *testing.T) {
@@ -150,6 +152,7 @@ func TestTeams_MessageFields(t *testing.T) {
 			Sections:        "[{\"sections\": true}]",
 			PotentialAction: "[{\"actions\": true}]",
 			Title:           "Title",
+			ThemeColor:      "#000080",
 		},
 	}
 
@@ -164,6 +167,7 @@ func TestTeams_MessageFields(t *testing.T) {
 
 	assert.Contains(t, receivedBody.Text, notification.Teams.Text)
 	assert.Contains(t, receivedBody.Title, notification.Teams.Title)
+	assert.Contains(t, receivedBody.ThemeColor, notification.Teams.ThemeColor)
 	assert.Contains(t, receivedBody.PotentialAction, teamsAction{"actions": true})
 	assert.Contains(t, receivedBody.Sections, teamsSection{"sections": true})
 	assert.EqualValues(t, receivedBody.Sections[len(receivedBody.Sections)-1]["facts"],


### PR DESCRIPTION
Teams also have theme color field for the message card, suggest for enabling templating it as Slack template supported.

Template example:

```yaml
template.app-sync-succeeded: |
  teams:
      themeColor: '#000080'
```