### PR TITLE
feat: support using multiple configmaps/secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,15 @@ test:
 lint:
 	golangci-lint run
 
+.PHONY: docs
+docs:
+	rm -rf vendor && go mod vendor && mkdir -p docs/services
+	cp -r vendor/github.com/argoproj/notifications-engine/docs/services/* docs/services && rm docs/services/*.go && rm -rf vendor
+	go run github.com/argoproj-labs/argocd-notifications/hack/gen docs
+
 .PHONY: catalog
 catalog:
 	go run github.com/argoproj-labs/argocd-notifications/hack/gen catalog
-	go run github.com/argoproj-labs/argocd-notifications/hack/gen docs
 
 .PHONY: manifests
 manifests:
@@ -26,7 +31,7 @@ tools:
 	go install github.com/golang/mock/mockgen@v1.5.0
 
 .PHONY: generate
-generate: manifests catalog tools
+generate: manifests docs catalog tools
 	go generate ./...
 
 .PHONY: build

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,34 +69,17 @@ For more information or to contribute, check out the [argoproj/argo-helm reposit
 
 ## Kustomize Getting Started
 
-argocd-notification manifests can also be installed using [Kustomize](https://kustomize.io/). To install
-argocd-notifications, we recommended saving a tagged release of the `install.yaml`:
-
-```shell
-curl -o argocd-notifications-v1.1.0-install.yaml https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.1.0/manifests/install.yaml
-```
-
-The tagged release should then be included in a `kustomization.yaml`:
-```yaml
-namespace: argocd
-resources:
-- argocd-notifications-v1.1.0-install.yaml
-```
-
-If you would like to also install Triggers and Templates from the Catalog, we recommend
-saving a tagged release of the catalog `install.yaml`:
-
-```shell
-curl -o argocd-notifications-catalog-v1.1.0-install.yaml https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.1.0/catalog/install.yaml
-```
-
-The tagged release should then be patched into the base argocd-notifications install
-manifest in your `kustomization.yaml`:
+The argocd-notification manifests can also be installed using [Kustomize](https://kustomize.io/). To install
+argocd-notifications, we recommend using the remote kustomize resource:
 
 ```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 namespace: argocd
 resources:
-- argocd-notifications-v1.1.0-install.yaml
+- https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/stable/manifests/install.yaml
+
 patchesStrategicMerge:
-- argocd-notifications-catalog-v1.1.0-install.yaml
+- https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/stable/catalog/install.yaml
 ```

--- a/docs/services/email.md
+++ b/docs/services/email.md
@@ -18,7 +18,7 @@ The following snippet contains sample Gmail service configuration:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.email.gmail: |
     username: $email-username
@@ -34,7 +34,7 @@ Without authentication:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.email.example: |
     host: smtp.example.com
@@ -50,7 +50,7 @@ Notification templates support specifying subject for email notifications:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   template.app-sync-succeeded: |
     email:

--- a/docs/services/github.md
+++ b/docs/services/github.md
@@ -24,7 +24,7 @@ in `argocd-notifications-cm` ConfigMap
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.github: |
     appID: <app-id>
@@ -36,7 +36,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argocd-notifications-secret
+  name: <secret-name>
 stringData:
   github-privateKey: |
     -----BEGIN RSA PRIVATE KEY-----

--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -15,7 +15,7 @@ To be able to create Grafana annotation with argocd-notifications you have to cr
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.grafana: |
     apiUrl: https://grafana.example.com/api
@@ -26,7 +26,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argocd-notifications-secret
+  name: <secret-name>
 stringData:
   grafana-api-key: api-key
 ```

--- a/docs/services/mattermost.md
+++ b/docs/services/mattermost.md
@@ -19,7 +19,7 @@ in `argocd-notifications-cm` ConfigMap
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.mattermost: |
     apiURL: <api-url>
@@ -30,7 +30,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argocd-notifications-secret
+  name: <secret-name>
 stringData:
   mattermost-token: token
 ```

--- a/docs/services/opsgenie.md
+++ b/docs/services/opsgenie.md
@@ -19,7 +19,7 @@ To be able to send notifications with argocd-notifications you have to create an
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.opsgenie: |
     apiUrl: <api-url>

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -12,9 +12,9 @@ The `slack` indicates that service sends slack notification; name is missing and
 
 ## Sensitive Data
 
-Sensitive data like authentication tokens should be stored in `argocd-notifications-secret` Secret and can be referenced in
+Sensitive data like authentication tokens should be stored in `<secret-name>` Secret and can be referenced in
 service configuration using `$<secret-key>` format. For example `$slack-token` referencing value of key `slack-token` in
-`argocd-notifications-secret` Secret.
+`<secret-name>` Secret.
 
 ## Custom Names
 

--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -19,7 +19,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argocd-notifications-secret
+  name: <secret-name>
 stringData:
   slack-token: <auth-token>
 ```
@@ -30,7 +30,7 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.slack: |
     apiURL: <url>                 # optional URL, e.g. https://example.com/api

--- a/docs/services/teams.md
+++ b/docs/services/teams.md
@@ -18,7 +18,7 @@ The Teams notification service send message notifications using Teams bot and re
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.teams: |
     recipientUrls:
@@ -29,7 +29,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: argocd-notifications-secret
+  name: <secret-name>
 stringData:
   channel-teams-url: https://example.com
 ```

--- a/docs/services/telegram.md
+++ b/docs/services/telegram.md
@@ -1,14 +1,14 @@
 # Telegram
 
 1. Get an API token using [@Botfather](https://t.me/Botfather).
-2. Store token in `argocd_notifications-secret` Secret and configure telegram integration
-in `argocd-notifications-cm` ConfigMap:
+2. Store token in `<secret-name>` Secret and configure telegram integration
+in `<config-map-name>` ConfigMap:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.telegram: |
     token: $telegram-token

--- a/docs/services/webhook.md
+++ b/docs/services/webhook.md
@@ -11,7 +11,7 @@ Use the following steps to configure webhook:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.webhook.<webhook-name>: |
     url: https://<hostname>/<optional-path>
@@ -29,7 +29,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   template.github-commit-status: |
     webhook:
@@ -57,7 +57,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.webhook.github: |
     url: https://api.github.com
@@ -72,7 +72,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.webhook.github: |
     url: https://api.github.com
@@ -103,7 +103,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.webhook.jenkins: |
     url: http://<jenkins-host>/job/<job-name>/build?token=<job-secret>
@@ -120,7 +120,7 @@ type: Opaque
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-notifications-cm
+  name: <config-map-name>
 data:
   service.webhook.form: |
     url: https://form.example.com

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,8 +1,10 @@
 The trigger defines the condition when the notification should be sent. The definition includes name, condition
-and notification templates reference.
+and notification templates reference. The condition is a predicate expression that returns true if the notification
+should be sent. The trigger condition evaluation is powered by [antonmedv/expr](https://github.com/antonmedv/expr).
+The condition language syntax is described at [Language-Definition.md](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
 
 The trigger is configured in `argocd-notifications-cm` ConfigMap. For example the following trigger sends a notification
-when application sync status changes to `Unknown` using `app-sync-status` template:
+when application sync status changes to `Unknown` using the `app-sync-status` template:
 
 ```yaml
 apiVersion: v1

--- a/docs/upgrading/1.0-1.1.md
+++ b/docs/upgrading/1.0-1.1.md
@@ -1,0 +1,3 @@
+# v1.0 to v1.1
+
+No changes that require special attention.

--- a/docs/upgrading/1.1-1.2.md
+++ b/docs/upgrading/1.1-1.2.md
@@ -1,0 +1,3 @@
+# v1.1 to v1.2
+
+No changes that require special attention.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/argoproj/argo-cd/v2 v2.0.0-rc3
 	github.com/argoproj/gitops-engine v0.3.1
-	github.com/argoproj/notifications-engine v0.1.0
+	github.com/argoproj/notifications-engine v0.1.1-0.20210422232742-d5670d855356
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
+github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -63,6 +65,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/RocketChat/Rocket.Chat.Go.SDK v0.0.0-20210112200207-10ab4d695d60 h1:prBTRx78AQnXzivNT9Crhu564W/zPPr3ibSlpT9xKcE=
+github.com/RocketChat/Rocket.Chat.Go.SDK v0.0.0-20210112200207-10ab4d695d60/go.mod h1:rjP7sIipbZcagro/6TCk6X0ZeFT2eyudH5+fve/cbBA=
 github.com/TomOnTime/utfutil v0.0.0-20180511104225-09c41003ee1d/go.mod h1:WML6KOYjeU8N6YyusMjj2qRvaPNUEvrQvaxuFcMRFJY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -89,8 +93,8 @@ github.com/argoproj/argo-cd/v2 v2.0.0-rc3 h1:jBuz8qqLL0gG6Nb892x3+eP+v/wjQpkdSOl
 github.com/argoproj/argo-cd/v2 v2.0.0-rc3/go.mod h1:Rw7fuyae0v8b3KMJoZp8jf5A2tBP2dQ8uWj9HTRZITo=
 github.com/argoproj/gitops-engine v0.3.1 h1:wM4RUzH54sWdchD7Ws8UdAIsjk08BmjN9bLuW79xKWk=
 github.com/argoproj/gitops-engine v0.3.1/go.mod h1:IBHhAkqlC+3r/wBWUitWSidQhPzlLoSTWp2htq3dyQk=
-github.com/argoproj/notifications-engine v0.1.0 h1:3I72OyeBo6FaY/Go2t2jqZjbuoHi9tQ/j0GbmpFE2Mc=
-github.com/argoproj/notifications-engine v0.1.0/go.mod h1:7ose9UGy6I58sGeoajOF00LiRtnCky2v2j2ypaNJ3VM=
+github.com/argoproj/notifications-engine v0.1.1-0.20210422232742-d5670d855356 h1:LLtvnkaTfOVQ/kzmToTdvWRvONRt7oPva3WZcTqefjo=
+github.com/argoproj/notifications-engine v0.1.1-0.20210422232742-d5670d855356/go.mod h1:28PD78dpU8MK+/juCRZQ3IPMOO3KZn7iN6aUBIMzGZQ=
 github.com/argoproj/pkg v0.2.0 h1:ETgC600kr8WcAi3MEVY5sA1H7H/u1/IysYOobwsZ8No=
 github.com/argoproj/pkg v0.2.0/go.mod h1:F4TZgInLUEjzsWFB/BTJBsewoEy0ucnKSq6vmQiD/yc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -184,6 +188,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
@@ -395,6 +400,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
+github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4 h1:4EZlYQIiyecYJlUbVkFXCXHz1QPhVXcHnQKAzBTPfQo=
+github.com/gopackage/ddp v0.0.0-20170117053602-652027933df4/go.mod h1:lEO7XoHJ/xNRBCxrn4h/CEB67h0kW1B0t4ooP2yrjUA=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -606,6 +613,7 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.2 h1:8mVmC9kjFFmA8H4pKMUhcblgifdkOIXPvbhN1T36q1M=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -613,6 +621,7 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -710,6 +719,8 @@ github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:s
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sony/sonyflake v1.0.0 h1:MpU6Ro7tfXwgn2l5eluf9xQvQJDROTBImNCfRXn/YeM=
+github.com/sony/sonyflake v1.0.0/go.mod h1:Jv3cfhf/UFtolOTTRd3q4Nl6ENqM+KfyZ5PseKfZGF4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -890,6 +901,7 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201022231255-08b38378de70/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201024042810-be3efd7ff127/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,0 +1,7 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/argoproj/notifications-engine/docs/services"
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,3 +50,5 @@ nav:
   - monitoring.md
   - Upgrading:
     - upgrading/0.x-1.0.md
+    - upgrading/1.0-1.1.md
+    - upgrading/1.1-1.2.md


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj-labs/argocd-notifications/issues/165
Closes https://github.com/argoproj-labs/argocd-notifications/issues/77

PR attempts to improve config management workflow and make it more "GitOps" friendly. Once PR is merged Argo CD Notifications won't use hardcoded ConfigMap/Secret names. Instead, it will discover all ConfigMaps and Secrets labels with `app.kubernetes.io/part-of: argocd-notifications` label and use merge keys for configuration. 

The main advantage is that settings don't have to be in one giant file. Another benefit is that `install.yaml` from catalog can be bundled as remote resource into kustomization.yaml file:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: argocd
resources:
- https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/stable/manifests/install.yaml
- https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/stable/catalog/install.yaml
```

