### PR TITLE
Fix syntax error in Teams notifications

### DIFF
--- a/catalog/install.yaml
+++ b/catalog/install.yaml
@@ -69,7 +69,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]
@@ -141,7 +141,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]
@@ -217,7 +217,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]
@@ -293,7 +293,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]
@@ -369,7 +369,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]
@@ -444,7 +444,7 @@ data:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/catalog/templates/app-deployed.yaml
+++ b/catalog/templates/app-deployed.yaml
@@ -56,7 +56,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/catalog/templates/app-health-degraded.yaml
+++ b/catalog/templates/app-health-degraded.yaml
@@ -48,7 +48,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/catalog/templates/app-sync-failed.yaml
+++ b/catalog/templates/app-sync-failed.yaml
@@ -52,7 +52,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/catalog/templates/app-sync-running.yaml
+++ b/catalog/templates/app-sync-running.yaml
@@ -51,7 +51,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/catalog/templates/app-sync-status-unknown.yaml
+++ b/catalog/templates/app-sync-status-unknown.yaml
@@ -52,7 +52,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/catalog/templates/app-sync-succeeded.yaml
+++ b/catalog/templates/app-sync-succeeded.yaml
@@ -52,7 +52,7 @@ teams:
           {{if $index}},{{end}}
           {
             "name": "{{$c.type}}",
-            "value": "{{$c.message}}",
+            "value": "{{$c.message}}"
           }
         {{end}}
         ]

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -91,7 +91,7 @@ teams:
       {{if $index}},{{end}}
       {
         "name": "{{$c.type}}",
-        "value": "{{$c.message}}",
+        "value": "{{$c.message}}"
       }
     {{end}}
     ]
@@ -167,7 +167,7 @@ teams:
       {{if $index}},{{end}}
       {
         "name": "{{$c.type}}",
-        "value": "{{$c.message}}",
+        "value": "{{$c.message}}"
       }
     {{end}}
     ]
@@ -247,7 +247,7 @@ teams:
       {{if $index}},{{end}}
       {
         "name": "{{$c.type}}",
-        "value": "{{$c.message}}",
+        "value": "{{$c.message}}"
       }
     {{end}}
     ]
@@ -327,7 +327,7 @@ teams:
       {{if $index}},{{end}}
       {
         "name": "{{$c.type}}",
-        "value": "{{$c.message}}",
+        "value": "{{$c.message}}"
       }
     {{end}}
     ]
@@ -407,7 +407,7 @@ teams:
       {{if $index}},{{end}}
       {
         "name": "{{$c.type}}",
-        "value": "{{$c.message}}",
+        "value": "{{$c.message}}"
       }
     {{end}}
     ]
@@ -486,7 +486,7 @@ teams:
       {{if $index}},{{end}}
       {
         "name": "{{$c.type}}",
-        "value": "{{$c.message}}",
+        "value": "{{$c.message}}"
       }
     {{end}}
     ]


### PR DESCRIPTION
There was a trailing comma at the end of the condition fact value
which made the JSON syntactically invalid causing notifications
to not be handled / published.