### PR TITLE
docs: Add RocketChat page to documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - services/teams.md
     - services/telegram.md
     - services/webhook.md
+    - services/rocketchat.md
   - catalog.md
   - troubleshooting.md
   - Bots:


### PR DESCRIPTION
Since Rocketchat documentation was finished by @alexmt. I guess we can add it into documentation website on master branch. If it's not released currently