### PR TITLE
chore: pin mkdocs version to fix docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-mkdocs-material
-markdown_include
+mkdocs==1.1.2
+mkdocs-material==7.1.7
+markdown_include==0.6.0
 pygments==2.7.4


### PR DESCRIPTION
Signed-off-by: Ryota Sakamoto <sakamo.ryota+github@gmail.com>

refs: https://github.com/argoproj/argo-cd/pull/6421