### PR TITLE
feat: add strings.ReplaceAll

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -12,6 +12,14 @@ Returns an instance of Golang [Time](https://golang.org/pkg/time/#Time).
 
 Parses specified string using RFC3339 layout. Returns an instance of Golang [Time](https://golang.org/pkg/time/#Time).
 
+### **strings**
+String related functions.
+
+<hr>
+**`strings.ReplaceAll() string`**
+
+Executes function built-in Golang [strings.ReplaceAll](https://pkg.go.dev/strings#ReplaceAll) function.
+
 ### **repo**
 Functions that provide additional information about Application source repository.
 <hr>

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"github.com/argoproj-labs/argocd-notifications/expr/repo"
+	"github.com/argoproj-labs/argocd-notifications/expr/strings"
 	"github.com/argoproj-labs/argocd-notifications/expr/time"
 	"github.com/argoproj-labs/argocd-notifications/shared/argocd"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -12,6 +13,7 @@ var helpers = map[string]interface{}{}
 func init() {
 	helpers = make(map[string]interface{})
 	register("time", time.NewExprs())
+	register("strings", strings.NewExprs())
 }
 
 func register(namespace string, entry map[string]interface{}) {

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -10,6 +10,7 @@ func TestExpr(t *testing.T) {
 	namespaces := []string{
 		"time",
 		"repo",
+		"strings",
 	}
 
 	for _, ns := range namespaces {

--- a/expr/strings/strings.go
+++ b/expr/strings/strings.go
@@ -1,0 +1,13 @@
+package strings
+
+import "strings"
+
+func NewExprs() map[string]interface{} {
+	return map[string]interface{}{
+		"ReplaceAll": replaceAll,
+	}
+}
+
+func replaceAll(s, old, new string) string {
+	return strings.ReplaceAll(s, old, new)
+}

--- a/expr/strings/strings_test.go
+++ b/expr/strings/strings_test.go
@@ -1,0 +1,19 @@
+package strings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewExprs(t *testing.T) {
+	funcs := []string{
+		"ReplaceAll",
+	}
+
+	for _, fn := range funcs {
+		stringsExprs := NewExprs()
+		_, hasFunc := stringsExprs[fn]
+		assert.True(t, hasFunc)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ryota Sakamoto <sakamo.ryota+github@gmail.com>

close #332 

---

Call function about `.stringse.ReplaceAll` in template, then it can be rendered multi line message.

```
{
  "title": "Commit Message",
  "value": "{{ (call .strings.ReplaceAll (call .repo.GetCommitMetadata .app.status.sync.revision).Message "\n" "\\n" ) }}",
  "short": true
}
```

![image](https://user-images.githubusercontent.com/18019529/137358627-ff9eee98-aacd-418f-a6e5-7c6c623b3fc6.png)
