### PR TITLE
feat: add sync.GetInfoItem function

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -20,6 +20,13 @@ String related functions.
 
 Executes function built-in Golang [strings.ReplaceAll](https://pkg.go.dev/strings#ReplaceAll) function.
 
+### **sync**
+
+<hr>
+**`sync.GetInfoItem(app map, name string) string`**
+
+Returns the `info` item value by given name stored in the Argo CD App sync operation.
+
 ### **repo**
 Functions that provide additional information about Application source repository.
 <hr>

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -3,6 +3,7 @@ package expr
 import (
 	"github.com/argoproj-labs/argocd-notifications/expr/repo"
 	"github.com/argoproj-labs/argocd-notifications/expr/strings"
+	"github.com/argoproj-labs/argocd-notifications/expr/sync"
 	"github.com/argoproj-labs/argocd-notifications/expr/time"
 	"github.com/argoproj-labs/argocd-notifications/shared/argocd"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,6 +15,7 @@ func init() {
 	helpers = make(map[string]interface{})
 	register("time", time.NewExprs())
 	register("strings", strings.NewExprs())
+	register("sync", sync.NewExprs())
 }
 
 func register(namespace string, entry map[string]interface{}) {

--- a/expr/sync/sync.go
+++ b/expr/sync/sync.go
@@ -1,0 +1,49 @@
+package sync
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func NewExprs() map[string]interface{} {
+	return map[string]interface{}{
+		"GetInfoItem": func(app map[string]interface{}, name string) string {
+			res, err := getInfoItem(app, name)
+			if err != nil {
+				panic(err)
+			}
+			return res
+		},
+	}
+}
+
+func getInfoItem(app map[string]interface{}, name string) (string, error) {
+	un := unstructured.Unstructured{Object: app}
+	operation, ok, _ := unstructured.NestedMap(app, "operation")
+	if !ok {
+		operation, ok, _ = unstructured.NestedMap(app, "status", "operationState", "operation")
+	}
+	if !ok {
+		return "", fmt.Errorf("application '%s' has no operation", un.GetName())
+	}
+
+	infoItems, ok := operation["info"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("application '%s' has no info items", un.GetName())
+	}
+	for _, infoItem := range infoItems {
+		item, ok := infoItem.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if item["name"] == name {
+			res, ok := item["value"].(string)
+			if !ok {
+				return "", fmt.Errorf("application '%s' has invalid value of info item '%s'", un.GetName(), name)
+			}
+			return res, nil
+		}
+	}
+	return "", fmt.Errorf("application '%s' has no info item with name '%s'", un.GetName(), name)
+}

--- a/expr/sync/sync_test.go
+++ b/expr/sync/sync_test.go
@@ -1,0 +1,50 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/argoproj-labs/argocd-notifications/testing"
+)
+
+var (
+	infoItems = []interface{}{
+		map[string]interface{}{
+			"name":  "name1",
+			"value": "val1",
+		},
+	}
+)
+
+func TestGetInfoItem_RequestedOperation(t *testing.T) {
+	app := NewApp("test")
+	app.Object["operation"] = map[string]interface{}{
+		"info": infoItems,
+	}
+
+	val, err := getInfoItem(app.Object, "name1")
+	assert.NoError(t, err)
+	assert.Equal(t, "val1", val)
+}
+
+func TestGetInfoItem_CompletedOperation(t *testing.T) {
+	app := NewApp("test")
+	app.Object["status"] = map[string]interface{}{
+		"operationState": map[string]interface{}{
+			"operation": map[string]interface{}{
+				"info": infoItems,
+			},
+		},
+	}
+
+	val, err := getInfoItem(app.Object, "name1")
+	assert.NoError(t, err)
+	assert.Equal(t, "val1", val)
+}
+
+func TestGetInfoItem_NoOperation(t *testing.T) {
+	app := NewApp("test")
+	_, err := getInfoItem(app.Object, "name1")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR adds `sync.GetInfoItem` that simplifies retrieving operation info items by name