### PR TITLE
Expose time.LoadLocation to template system

### DIFF
--- a/expr/time/time.go
+++ b/expr/time/time.go
@@ -8,6 +8,7 @@ func NewExprs() map[string]interface{} {
 	return map[string]interface{}{
 		"Parse": parse,
 		"Now":   now,
+		"LoadLocation": load_location,
 	}
 }
 
@@ -21,4 +22,12 @@ func parse(timestamp string) time.Time {
 
 func now() time.Time {
 	return time.Now()
+}
+
+func load_location(location string) time.Location {
+	loc, err := time.LoadLocation(location)
+	if err != nil {
+		panic(err)
+	}
+	return loc
 }


### PR DESCRIPTION
This allow to render time dates with custom time zones, for example if you have a devops team in different time zones and you want create a message template with the `.app.status.operationState.finishedAt` rendered to different locations.

Message example: 
```
Application `{{.app.metadata.name}}` has been successfully synced at 

`UTC Time:` {{ (call .time.Parse .app.status.operationState.finishedAt).UTC.Format "02-January-2006 03:04pm" }}.
`Cuban Time:` {{ ((call .time.Parse .app.status.operationState.finishedAt).In (call .time.LoadLocation "America/Havana")).Format "02-January-2006 03:04pm" }}.
```