### PR TITLE
Fix : remove git suffix.

### DIFF
--- a/expr/repo/repo.go
+++ b/expr/repo/repo.go
@@ -81,6 +81,7 @@ func repoURLToHTTPS(rawURL string) string {
 	}
 	parsed.Scheme = "https"
 	parsed.User = nil
+	parsed.Path = gitSuffix.ReplaceAllString(parsed.Path, "")
 	return parsed.String()
 }
 


### PR DESCRIPTION

"repoURLToHTTPS" returns below.
```
https://github.com/argoproj-labs/argocd-notifications.git
```

But this URL ( with .git suffix ) is 404.
```
https://github.com/argoproj-labs/argocd-notifications.git/blob/master/Dockerfile
```

This URL is correct.
```
https://github.com/argoproj-labs/argocd-notifications/blob/master/Dockerfile
```
