### PR TITLE
docs: warn about new documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,11 @@
-# Overview
+
+# Argo CD Notifications is now part of Argo CD
+
+This documentation has moved to the [main Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/).
+
+The Argo CD notifications project is now merged with Argo CD and released along with it.
+
+## Overview
 
 Argo CD Notifications continuously monitors Argo CD applications and provides a flexible way to notify
 users about important changes in the application state. Using a flexible mechanism of


### PR DESCRIPTION
Hi,

While the README is explicit about it, the documentation at https://argocd-notifications.readthedocs.io/en/stable does not warn about the move to the main ArgoCD documentation, this should help.

thanks