### PR TITLE
Update Overview docs guide with latest release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,13 +11,13 @@ So you can just use them instead of reinventing new ones.
 * Install Argo CD Notifications
 
 ```
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.1.0/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.2.1/manifests/install.yaml
 ```
 
 * Install Triggers and Templates from the catalog
 
 ```
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.1.0/catalog/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.2.1/catalog/install.yaml
 ```
 
 * Add Email username and password token to `argocd-notifications-secret` secret


### PR DESCRIPTION
Update Overview docs guide with latest current stable release (1.21.), in order to get the latest distribution.